### PR TITLE
Respect per-validator YardOptions when considering element visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # YARD-Lint Changelog
 
 ## 1.3.0 (Unreleased)
+- **[Fix]** Respect per-validator `YardOptions` when filtering by visibility (#41)
+  - Executor was ignoring `YardOptions` defined on individual validators
+  - Specifying `YardOptions` on a specific validator now correctly overrides `AllValidators` defaults
+  - Enables use cases like validating tag order on private methods, but skipping documentation requirement
+  - Example: Set `--private` in `AllValidators.YardOptions`, then override with empty `YardOptions: []` on `Documentation/UndocumentedObjects` to skip private methods or constants
 - **[Feature]** Add in-process YARD execution for ~10x faster performance
   - Parses files once and shares the YARD registry across all validators
   - Eliminates subprocess spawning overhead (previously spawned 17+ processes per run)

--- a/lib/yard/lint/executor/query_executor.rb
+++ b/lib/yard/lint/executor/query_executor.rb
@@ -86,7 +86,7 @@ module Yard
         def determine_visibility(validator)
           # Check if config specifies private/protected analysis
           if validator.config
-            yard_options = validator.config.all_validators['YardOptions'] || []
+            yard_options = validator.config.validator_yard_options(validator.class.validator_name)
             if yard_options.any? { |opt| opt.include?('--private') || opt.include?('--protected') }
               return :all
             end

--- a/spec/integrations/fixtures/private_constants.rb
+++ b/spec/integrations/fixtures/private_constants.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# ANSI helper class for colorizing output.
+class AnsiHelper
+  RED = 31
+
+  private_constant :RED
+
+  def red(text)
+    colorize(text, RED)
+  end
+
+  private
+
+  # Colorize text with ANSI escape codes.
+  # @return [String] the colorized text
+  # @param text [String] the text to colorize
+  # @param color [Symbol] the color to use
+  def colorize(text, color)
+    "\e[#{color}m#{text}\e[0m"
+  end
+end


### PR DESCRIPTION
With the recent changes, executor ignores `YardOptions` defined on each validator. This does not allow to have default options `--private` and then disable this on a specific validator (to skip documenting private methods or constants).

For example,

```yaml
AllValidators:
  YardOptions:
    - --private
Documentation/UndocumentedObjects:
  YardOptions: []
```

```ruby
class AnsiHelper
  RED = 31

  private_constant :RED
end
```

The validator should verify missing documentation for the class, but not the constant.

I have considered re-using existing fixtures, but feel like explicitly testing `private_constant` in at least one scenarios would be beneficial for the project overall.