### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # YARD-Lint Changelog
 
-## 1.3.0 (Unreleased)
+## 1.3.0 (2025-12-10)
 - **[Fix]** Expand `Tags/Order` default `EnforcedOrder` to include all standard YARD tags
   - Previous config only included: `param`, `option`, `return`, `raise`, `example`
   - Now includes full order: `param`, `option`, `yield`, `yieldparam`, `yieldreturn`, `return`, `raise`, `see`, `example`, `note`, `todo`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yard-lint (1.3.0.rc1)
+    yard-lint (1.3.0)
       yard (~> 0.9)
       zeitwerk (~> 2.6)
 

--- a/lib/yard/lint/version.rb
+++ b/lib/yard/lint/version.rb
@@ -3,6 +3,6 @@
 module Yard
   module Lint
     # @return [String] version of the YARD Lint gem
-    VERSION = '1.3.0.rc1'
+    VERSION = '1.3.0'
   end
 end


### PR DESCRIPTION
## Summary

- Updates version from `1.3.0.rc1` to `1.3.0`
- Sets release date to 2025-12-10 in CHANGELOG.md

## Test plan

- [ ] CI passes
- [ ] Merge and tag for release