### PR TITLE
fix: handle directive definitions depending on file load order

### DIFF
--- a/lib/yard/lint/executor/in_process_registry.rb
+++ b/lib/yard/lint/executor/in_process_registry.rb
@@ -33,6 +33,15 @@ module Yard
             original_level = YARD::Logger.instance.level
             YARD::Logger.instance.level = 4 # Only show fatal errors
 
+            # First pass: parse all files to process directive definitions
+            YARD.parse(files)
+
+            # Clear checksums to force reparsing without clearing the registry.
+            # This allows macro definitions from the first pass to be available
+            # during the second pass, enabling proper directive expansion regardless of parse order.
+            YARD::Registry.checksums.clear
+
+            # Second pass: reparse files now that all directive definitions are available
             @warnings = capture_warnings { YARD.parse(files) }
             @parsed = true
 

--- a/spec/integrations/fixtures/macro_a.rb
+++ b/spec/integrations/fixtures/macro_a.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Macro definition and usage in the same file
+class MacroA
+  # @!macro testing
+  #   @param some_key [String] Some Key
+  # @macro testing
+  def self.a_method(some_key)
+    puts some_key
+  end
+end

--- a/spec/integrations/fixtures/macro_b.rb
+++ b/spec/integrations/fixtures/macro_b.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "./macro_a"
+
+# Macro usage with definition in another file
+class MacroB
+  # @macro testing
+  def self.b_method(some_key)
+    MacroA.a_method(some_key)
+  end
+end

--- a/spec/integrations/macro_spec.rb
+++ b/spec/integrations/macro_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'Macro Integration' do
+  let(:fixtures_path) do
+    [
+      File.expand_path('fixtures/macro_a.rb', __dir__),
+      File.expand_path('fixtures/macro_b.rb', __dir__)
+    ]
+  end
+
+  describe 'Macro attachment and expansion' do
+    let(:config) { test_config }
+
+    it 'correctly attaches and expands macros across files' do
+      result = Yard::Lint.run(path: fixtures_path, config: config, progress: false)
+
+      expect(result.count).to be == 0
+    end
+
+    it 'correctly attaches and expands macros across files reversed order' do
+      result = Yard::Lint.run(path: fixtures_path.reverse, config: config, progress: false)
+
+      expect(result.count).to be == 0
+    end
+  end
+end


### PR DESCRIPTION
Resolves #64 

By parsing files twice, there will be a performance penalty, but the trade off will enable correct handling of directives (like `@!macro`) that are defined in different files from where they are used.