### PR TITLE
Update ruby/setup-ruby action to v1.268.0 in push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@2a7b30092b0caf9c046252510f9273b4875f3db9 # v1.254.0
+        uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
         with:
           ruby-version: '4.0'
           bundler-cache: false


### PR DESCRIPTION
## Summary
- Updates `ruby/setup-ruby` action from v1.254.0 to v1.268.0 in push.yml
- Aligns with the version already used in ci.yml for consistency
- Fixes release workflow issues with Ruby 4.0 support

## Test plan
- [x] Verify push workflow can execute successfully with the updated action
- [x] Confirm release process works with Ruby 4.0