### PR TITLE
fix: guard against nil location in TodoGenerator#make_relative_path

### DIFF
--- a/lib/yard/lint/runner.rb
+++ b/lib/yard/lint/runner.rb
@@ -108,12 +108,18 @@ module Yard
       end
 
       # Filter result offenses based on per-validator exclusions
-      # Removes offenses where the file path matches exclusion patterns
+      # Also always removes offenses with no file location (e.g. YARD warnings
+      # emitted without file context such as from macro expansion with nil object)
+      # since they carry no actionable information and would display as `:0`.
       # @param validator_name [String] full validator name
       # @param result [Results::Base] result object with offenses
       # @return [Results::Base, nil] result with filtered offenses, or nil if no offenses remain
       def filter_result_offenses(validator_name, result)
         validator_excludes = config.validator_all_excludes(validator_name)
+
+        # Drop offenses with no file location regardless of exclusion config
+        result.offenses = result.offenses.reject { |o| (o[:location] || o[:file]).nil? }
+        return nil if result.offenses.empty?
         return result if validator_excludes.empty?
 
         working_dir = Dir.pwd

--- a/lib/yard/lint/todo_generator.rb
+++ b/lib/yard/lint/todo_generator.rb
@@ -95,8 +95,8 @@ module Yard
           validator_result = result_builder.build(validator_name, raw_results)
           next unless validator_result && validator_result.offenses.any?
 
-          # Extract file paths from offenses
-          file_paths = validator_result.offenses.map do |offense|
+          # Extract file paths from offenses, skipping those without a location
+          file_paths = validator_result.offenses.filter_map do |offense|
             make_relative_path(offense[:location])
           end.uniq.sort
 
@@ -128,9 +128,11 @@ module Yard
       end
 
       # Convert absolute path to relative path from current directory
-      # @param path [String] absolute or relative file path
-      # @return [String] relative path from current directory
+      # @param path [String, nil] absolute or relative file path
+      # @return [String, nil] relative path from current directory, or nil if path is nil
       def make_relative_path(path)
+        return path if path.nil?
+
         pwd = Dir.pwd
         path.start_with?(pwd) ? path.sub("#{pwd}/", '') : path
       end

--- a/lib/yard/lint/validators/warnings/duplicated_parameter_name/parser.rb
+++ b/lib/yard/lint/validators/warnings/duplicated_parameter_name/parser.rb
@@ -6,9 +6,6 @@ module Yard
       module Warnings
         module DuplicatedParameterName
           # Parser for DuplicatedParameterName warnings
-          # YARD output format:
-          #   [warn]: @param tag has duplicate parameter name: ...
-          #       in file `filename.rb' near line N
           class Parser < ::Yard::Lint::Parsers::TwoLineBase
             # Set of regexps for detecting warnings reported by YARD stats
             self.regexps = {

--- a/lib/yard/lint/validators/warnings/duplicated_parameter_name/parser.rb
+++ b/lib/yard/lint/validators/warnings/duplicated_parameter_name/parser.rb
@@ -6,13 +6,16 @@ module Yard
       module Warnings
         module DuplicatedParameterName
           # Parser for DuplicatedParameterName warnings
-          class Parser < ::Yard::Lint::Parsers::OneLineBase
+          # YARD output format:
+          #   [warn]: @param tag has duplicate parameter name: ...
+          #       in file `filename.rb' near line N
+          class Parser < ::Yard::Lint::Parsers::TwoLineBase
             # Set of regexps for detecting warnings reported by YARD stats
             self.regexps = {
               general: /^\[warn\]: @param tag has duplicate parameter name/,
-              message: /\[warn\]: (.*) in file/,
-              location: /in file `(.*)`/,
-              line: /line (\d*)/
+              message: /\[warn\]: (.*)$/,
+              location: /in file `(.*?)'\s*near/,
+              line: /near line (\d+)/
             }.freeze
           end
         end

--- a/test/integrations/todo_generation_test.rb
+++ b/test/integrations/todo_generation_test.rb
@@ -428,5 +428,34 @@ describe 'Todo Generation' do
     assert_equal(1, result[:exit_code])
     assert_includes(result[:stdout], 'Error')
   end
+
+  # -- regression: nil location (issue #150) --
+
+  # A @!macro [new] body that contains an invalid tag format and is also
+  # referenced inside the defining method's body comment causes YARD to expand
+  # the macro with object=nil. That emits 'Invalid tag format for @return'
+  # WITHOUT the "in file `...`" fragment, so Warnings/InvalidTagFormat's
+  # parser returns offense[:location] = nil. Without the fix, --auto-gen-config
+  # crashes with NoMethodError in make_relative_path.
+  it 'regression nil location auto gen config does not crash when InvalidTagFormat warning has no file context' do
+    FileUtils.mkdir_p('lib')
+
+    File.write('lib/dsl_macro.rb', <<~RUBY)
+      class Api
+        # @!macro [new] dsl_method
+        #   @return attr_name [String] invalid: name before type list
+        def self.dsl_method(name)
+          # @!macro dsl_method
+        end
+
+        dsl_method :color
+      end
+    RUBY
+
+    result = run_yard_lint('--auto-gen-config')
+
+    assert_equal(0, result[:exit_code])
+    assert(File.exist?('.yard-lint-todo.yml'))
+  end
 end
 

--- a/test/yard/lint/todo_generator_test.rb
+++ b/test/yard/lint/todo_generator_test.rb
@@ -343,5 +343,52 @@ describe 'Yard::Lint::TodoGenerator' do
       assert_equal(relative, result)
     end
   end
+
+  # Regression test for https://github.com/mensfeld/yard-lint/issues/150
+  # YARD warnings without a file path (e.g. global-level warnings) produce
+  # offenses with location: nil. make_relative_path must not call start_with?
+  # on nil.
+  it 'make relative path returns nil for nil path without raising' do
+    Dir.chdir(@test_dir) do
+      generator = Yard::Lint::TodoGenerator.new(
+        path: '.',
+        config: @config,
+        force: false,
+        exclude_limit: 15
+      )
+
+      result = generator.send(:make_relative_path, nil)
+
+      assert_nil(result)
+    end
+  end
+
+  # Regression test for https://github.com/mensfeld/yard-lint/issues/150
+  # generate must not crash when a validator produces an offense with nil
+  # location (e.g. a YARD warning that lacks an "in file" component).
+  it 'generate does not crash when offense has nil location' do
+    Dir.chdir(@test_dir) do
+      FileUtils.mkdir_p('lib')
+      File.write('lib/test.rb', "class Test\nend\n")
+
+      # Inject a raw result for Warnings/UnknownTag whose stdout contains a
+      # warning that matches the parser's :general regex but omits the
+      # "in file `...`" fragment, so that offense[:location] is nil.
+      nil_location_stdout = "[warn]: Unknown tag @custom near line 1"
+
+      Yard::Lint::Runner.any_instance.stubs(:run_validators).returns(
+        unknown_tag: { stdout: nil_location_stdout, stderr: '', exit_code: 0 }
+      )
+
+      result = Yard::Lint::TodoGenerator.generate(
+        path: 'lib',
+        config: @config,
+        force: false,
+        exclude_limit: 15
+      )
+
+      assert_kind_of(Hash, result)
+    end
+  end
 end
 

--- a/test/yard/lint/todo_generator_test.rb
+++ b/test/yard/lint/todo_generator_test.rb
@@ -364,21 +364,29 @@ describe 'Yard::Lint::TodoGenerator' do
   end
 
   # Regression test for https://github.com/mensfeld/yard-lint/issues/150
-  # generate must not crash when a validator produces an offense with nil
-  # location (e.g. a YARD warning that lacks an "in file" component).
-  it 'generate does not crash when offense has nil location' do
+  #
+  # A @!macro [new] body that contains an invalid tag format (@return with a
+  # name before the type list) and is also referenced inside the defining
+  # method's own body comment causes YARD to expand the macro with object=nil.
+  # That emits 'Invalid tag format for @return' WITHOUT file context.
+  # Warnings/InvalidTagFormat's :general regex matches that warning, but its
+  # :location regex does not → offense[:location] is nil → NoMethodError on
+  # the unfixed make_relative_path.
+  it 'generate does not crash when YARD emits an InvalidTagFormat warning without file context' do
     Dir.chdir(@test_dir) do
       FileUtils.mkdir_p('lib')
-      File.write('lib/test.rb', "class Test\nend\n")
 
-      # Inject a raw result for Warnings/UnknownTag whose stdout contains a
-      # warning that matches the parser's :general regex but omits the
-      # "in file `...`" fragment, so that offense[:location] is nil.
-      nil_location_stdout = "[warn]: Unknown tag @custom near line 1"
+      File.write('lib/dsl_macro.rb', <<~RUBY)
+        class Api
+          # @!macro [new] dsl_method
+          #   @return attr_name [String] invalid: name before type list
+          def self.dsl_method(name)
+            # @!macro dsl_method
+          end
 
-      Yard::Lint::Runner.any_instance.stubs(:run_validators).returns(
-        unknown_tag: { stdout: nil_location_stdout, stderr: '', exit_code: 0 }
-      )
+          dsl_method :color
+        end
+      RUBY
 
       result = Yard::Lint::TodoGenerator.generate(
         path: 'lib',

--- a/test/yard/lint/validators/warnings/duplicated_parameter_name/parser_test.rb
+++ b/test/yard/lint/validators/warnings/duplicated_parameter_name/parser_test.rb
@@ -7,8 +7,8 @@ describe 'Yard::Lint::Validators::Warnings::DuplicatedParameterName::Parser' do
     @parser = Yard::Lint::Validators::Warnings::DuplicatedParameterName::Parser.new
   end
 
-  it 'initialize inherits from onelinebase parser' do
-    assert_kind_of(Yard::Lint::Parsers::OneLineBase, parser)
+  it 'initialize inherits from twolinebase parser' do
+    assert_kind_of(Yard::Lint::Parsers::TwoLineBase, parser)
   end
 
   it 'regexps defines required regexps' do


### PR DESCRIPTION
## Root Cause

When `yard-lint --auto-gen-config` runs, it calls `TodoGenerator#make_relative_path` on every offense location to build the exclusion list. If the location is `nil`, `String#start_with?` raises `NoMethodError` and the command crashes.

The nil location arises from a specific YARD code path: a `@!macro [new]` definition whose body contains an invalid tag format (e.g. `@return name [Type]` — name before the type list) **and** whose defining method's body also references that macro via `# @!macro name`. During YARD's second-pass re-parse, `MacroObject.apply` expands the macro by calling `parser.parse(docstring, nil, handler)` — passing `nil` as the code object. When YARD then raises `TagFormatError` internally, it catches it and logs:

```
[warn]: Invalid tag format for @return: ...
```

…without appending `in file '...' near line N` because `object` is `nil`. The `Warnings/InvalidTagFormat` parser's `:general` regex matches this warning (it doesn't require `near line`), but its `:location` regex does not — so `offense[:location]` ends up `nil`. `TodoGenerator#run_linting` then calls `make_relative_path(nil)` → crash.

**Second bug uncovered while fixing the display side:** `DuplicatedParameterName::Parser` was inheriting from `OneLineBase` even though YARD emits this warning over two lines (same format as `UnknownParameterName`). Its location regex also used backtick-on-both-sides (`` `path` ``) instead of the correct YARD format (`` `path' ``). This meant `offense[:location]` was always `nil` for `DuplicatedParameterName`, silently hiding those offenses from output.

## Changes

**`lib/yard/lint/todo_generator.rb`**
- `make_relative_path`: return early when `path` is `nil` (the direct crash fix)
- `run_linting`: use `filter_map` instead of `map` so nil paths are dropped when building the exclusion list

**`lib/yard/lint/runner.rb`**
- `filter_result_offenses`: always strip offenses with no file location before applying exclusion-pattern filtering; nil-location offenses carry no actionable information and would otherwise appear as `:0` in output

**`lib/yard/lint/validators/warnings/duplicated_parameter_name/parser.rb`**
- Switch from `OneLineBase` to `TwoLineBase` (YARD emits this warning on two lines)
- Fix `message` regex to capture the full first line
- Fix `location` regex to use backtick-open/single-quote-close (`` `path' ``), matching the actual YARD output format
- Fix `line` regex to use `near line (\d+)` for consistency

**Tests**
- Unit test: `make_relative_path` returns `nil` for `nil` input without raising
- Unit test: `generate` does not crash when YARD emits an `InvalidTagFormat` warning without file context (real fixture — a `@!macro [new]` with invalid tag format + self-referencing macro expansion)
- Integration test: `--auto-gen-config` does not crash on the same fixture via the CLI

## Test plan

- [ ] `bundle exec rake test` — all 1851 tests pass
- [ ] `yard-lint --auto-gen-config lib/dsl_macro.rb` with the macro fixture — exits 0
- [ ] Regular `yard-lint` run no longer shows offenses with `:0` location
- [ ] `DuplicatedParameterName` offenses now show correct file + line in output