### PR TITLE
feat: exempt @param on Struct.new / Data.define constants from MeaninglessTag

### DIFF
--- a/lib/yard/lint/validators/tags/meaningless_tag/validator.rb
+++ b/lib/yard/lint/validators/tags/meaningless_tag/validator.rb
@@ -22,8 +22,13 @@ module Yard
 
               return unless invalid_types.include?(object_type)
 
+              # @param is meaningful on Struct.new / Data.define constants because
+              # Solargraph uses those annotations to type the synthesized accessors.
+              effective_tags = struct_or_data_class?(object) ? tags_to_check - ['param'] : tags_to_check
+              return if effective_tags.empty?
+
               object.docstring.tags.each do |tag|
-                next unless tags_to_check.include?(tag.tag_name)
+                next unless effective_tags.include?(tag.tag_name)
 
                 collector.puts "#{object.file}:#{object.line}: #{object.title}"
                 collector.puts "#{object_type}|#{tag.tag_name}"
@@ -41,6 +46,16 @@ module Yard
             # @return [Array<String>] object types that shouldn't have method-only tags
             def invalid_object_types
               config_or_default('InvalidObjectTypes')
+            end
+
+            # @param object [YARD::CodeObjects::Base] the code object to inspect
+            # @return [Boolean] true when the object is a class synthesised by Struct.new
+            #   or Data.define, where @param documents the generated accessors
+            def struct_or_data_class?(object)
+              return false unless object.type == :class
+
+              sc_path = object.superclass&.path
+              sc_path == 'Struct' || sc_path == 'Data'
             end
           end
         end

--- a/test/fixtures/meaningless_tag_examples.rb
+++ b/test/fixtures/meaningless_tag_examples.rb
@@ -74,3 +74,17 @@ module SomeModule
   # @param wrong [String] this is wrong
   CONST_WITH_PARAM = 'value'
 end
+
+# Valid: Struct.new constant with @param (Solargraph uses these to type accessors)
+# @param required_gems [Array<String>]
+# @param helper_modules [Array<String>]
+GemHelpers = Struct.new(:required_gems, :helper_modules, keyword_init: true)
+
+# Valid: Data.define constant with @param (same reason)
+# @param x [Integer]
+# @param y [Integer]
+Point = Data.define(:x, :y)
+
+# Invalid: Struct.new constant with @option (still meaningless)
+# @option opts [String] :key This doesn't belong here
+StructWithOption = Struct.new(:key)

--- a/test/integrations/meaningless_tag_test.rb
+++ b/test/integrations/meaningless_tag_test.rb
@@ -77,5 +77,37 @@ describe 'Meaningless Tag' do
     meaningless_tag_offenses = result.offenses.select { |o| o[:name] == 'MeaninglessTag' }
     assert_empty(meaningless_tag_offenses)
   end
+
+  # -- Struct.new / Data.define --
+
+  it 'does not flag @param on Struct.new constants' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offenses = result.offenses.select do |o|
+      o[:name] == 'MeaninglessTag' && o[:message].include?('GemHelpers')
+    end
+
+    assert_empty(offenses)
+  end
+
+  it 'does not flag @param on Data.define constants' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offenses = result.offenses.select do |o|
+      o[:name] == 'MeaninglessTag' && o[:message].include?('Point')
+    end
+
+    assert_empty(offenses)
+  end
+
+  it 'still flags @option on Struct.new constants' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offenses = result.offenses.select do |o|
+      o[:name] == 'MeaninglessTag' && o[:message].include?('StructWithOption')
+    end
+
+    refute_empty(offenses)
+  end
 end
 


### PR DESCRIPTION
Fixes #152.

## Why

`Struct.new` and `Data.define` constant assignments are handled by YARD as class objects with `Struct` / `Data` as their superclass. `Tags/MeaninglessTag` was flagging `@param` tags on these because constants/classes are in `InvalidObjectTypes`.

Since Solargraph [castwide/solargraph#970](https://github.com/castwide/solargraph/pull/970) / [#939](https://github.com/castwide/solargraph/pull/939), `@param` on these constants is actively consumed — it types the synthesised accessor methods (`required_gems`, `x`, etc.). Flagging them as meaningless is a false positive.

## What changed

**`lib/yard/lint/validators/tags/meaningless_tag/validator.rb`**
- Added `struct_or_data_class?` private helper that detects a YARD `ClassObject` whose `superclass.path` is `"Struct"` or `"Data"`
- In `in_process_query`, when that helper returns true, exclude `"param"` from the tags being checked — `@option` is still reported because it remains meaningless on these constants

**`test/fixtures/meaningless_tag_examples.rb`**
- `GemHelpers = Struct.new(...)` with `@param` — should not be flagged
- `Point = Data.define(...)` with `@param` — should not be flagged
- `StructWithOption = Struct.new(...)` with `@option` — should still be flagged

**`test/integrations/meaningless_tag_test.rb`**
- Three new tests covering the above cases

## Test plan

- [ ] `bundle exec rake test` — all tests pass
- [ ] `yard-lint lib/` — no offenses (self-check)
- [ ] `yard-lint` on a file with `Struct.new`/`Data.define` constants — `@param` not flagged
- [ ] `@option` on a `Struct.new` constant — still flagged