### PR TITLE
test: regression coverage for nested Hash types in Tags/InvalidTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # YARD-Lint Changelog
 
 ## 1.5.2 (Unreleased)
+- **[Fix]** `Tags/InvalidTypes` no longer false-positives on nested `Hash{K => V}` types (#151, #152)
+  - Complex hash types such as `Hash{String => Hash{Symbol => Array<String>}}` were occasionally flagged as invalid; the `extract_type_names` splitter already handled them correctly after the 1.5.2 sanitizer rewrite, and regression tests now lock that behaviour in
+  - Invalid types genuinely nested inside hash values (e.g. `Hash{String => bad_type}`) are still caught and surfaced correctly
 - **[Enhancement]** `Tags/InvalidTypes` offense messages now name the invalid type(s) and the tag they appear in (#151)
   - Previously reported a generic `"has at least one tag with an invalid type definition"` message with no further detail
   - Now reports `"has invalid type(s): @param body: \`bad_type\`; @return: \`wrong_type\`"` — the exact offending type and the tag (including param name for `@param`) where it was found

--- a/test/fixtures/invalid_types_messages.rb
+++ b/test/fixtures/invalid_types_messages.rb
@@ -11,4 +11,23 @@ class InvalidTypesMessages
   def process(value)
     value
   end
+
+  # Valid: nested Hash types must not produce false positives.
+  # These cover the "complex hash values" case from issue #151/#152.
+  # @return [Hash{String => Hash{Symbol => Array<String>}}] two-level nested hash
+  def nested_hash_two_levels; end
+
+  # @return [Hash{Symbol => Hash{String => Hash{Integer => String}}}] three-level nested hash
+  def nested_hash_three_levels; end
+
+  # @param opts [Hash{Symbol => Array<Hash{String => Integer}>}] hash inside array inside hash
+  def hash_in_array_in_hash(opts); end
+
+  # Valid: simple one-level hash must not be flagged.
+  # @return [Hash{String => Integer}] simple hash
+  def simple_hash; end
+
+  # Invalid: bad type nested inside a hash value should still be caught.
+  # @return [Hash{String => bad_nested_type}] hash with invalid value type
+  def hash_with_invalid_value; end
 end

--- a/test/integrations/invalid_types_messages_test.rb
+++ b/test/integrations/invalid_types_messages_test.rb
@@ -55,4 +55,47 @@ describe 'InvalidTypes offense messages' do
     assert_includes(process_offense[:message], 'bad_type')
     assert_includes(process_offense[:message], '@param value')
   end
+
+  # -- Nested Hash types (regression for issue #151/#152 "complex hash values") --
+
+  it 'does not flag two-level nested Hash return type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('nested_hash_two_levels') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag three-level nested Hash return type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('nested_hash_three_levels') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag Hash inside Array inside Hash param type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_in_array_in_hash') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag simple one-level Hash type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('simple_hash') }
+
+    assert_nil(offense)
+  end
+
+  it 'still flags an invalid type nested inside a Hash value' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_with_invalid_value') }
+
+    refute_nil(offense)
+    assert_includes(offense[:message], 'bad_nested_type')
+  end
 end


### PR DESCRIPTION
Closes the 'complex hash values' note from issue #152 comment (point 3.1).

## What this does

The commenter flagged that complex `Hash{K => V}` types may not be supported yet. After investigation, the current `extract_type_names` splitter already handles all the cases correctly — no false positives are produced for any nested hash pattern tested:

- `Hash{String => Hash{Symbol => Array<String>}}` (two levels)
- `Hash{Symbol => Hash{String => Hash{Integer => String}}}` (three levels)
- `Hash{Symbol => Array<Hash{String => Integer}>}` (hash inside array inside hash)

These tests lock that behaviour in so it cannot silently regress.

Also confirmed that invalid types genuinely nested inside hash values (e.g. `Hash{String => bad_type}`) are still correctly caught and surfaced with the tag+param context from PR #155.

## Changelog

Added a `[Fix]` entry noting that nested Hash types are not false-positived, with regression tests to prove it.