### PR TITLE
fix: treat YARD pseudo-types undefined/unspecified/unknown as valid in Tags/InvalidTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # YARD-Lint Changelog
 
 ## 1.5.2 (Unreleased)
+- **[Fix]** `Tags/InvalidTypes` no longer false-positives on YARD pseudo-types `undefined`, `unspecified`, and `unknown` (#152)
+  - These lowercase pseudo-types are used in real-world YARD docs (e.g. Solargraph uses `Hash{String => undefined}` extensively) to signal that a type is intentionally unspecified
+  - They are now treated as valid types alongside the existing `nil`, `void`, `self`, `true`, `false` defaults
 - **[Fix]** `Tags/InvalidTypes` no longer false-positives on nested `Hash{K => V}` types (#151, #152)
   - Complex hash types such as `Hash{String => Hash{Symbol => Array<String>}}` were occasionally flagged as invalid; the `extract_type_names` splitter already handled them correctly after the 1.5.2 sanitizer rewrite, and regression tests now lock that behaviour in
   - Invalid types genuinely nested inside hash values (e.g. `Hash{String => bad_type}`) are still caught and surfaced correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - **[Fix]** `Tags/InvalidTypes` no longer false-positives on YARD pseudo-types `undefined`, `unspecified`, and `unknown` (#152)
   - These lowercase pseudo-types are used in real-world YARD docs (e.g. Solargraph uses `Hash{String => undefined}` extensively) to signal that a type is intentionally unspecified
   - They are now treated as valid types alongside the existing `nil`, `void`, `self`, `true`, `false` defaults
+- **[Fix]** `Tags/InvalidTypes` no longer false-positives on string literal hash keys (e.g. `Hash{"to" => String}`) (#152)
+  - String literal keys like `"email"` or `"name"` are valid YARD hash key notation and are now treated as valid alongside the existing symbol literal support (`:key`)
 - **[Fix]** `Tags/InvalidTypes` no longer false-positives on nested `Hash{K => V}` types (#151, #152)
   - Complex hash types such as `Hash{String => Hash{Symbol => Array<String>}}` were occasionally flagged as invalid; the `extract_type_names` splitter already handled them correctly after the 1.5.2 sanitizer rewrite, and regression tests now lock that behaviour in
   - Invalid types genuinely nested inside hash values (e.g. `Hash{String => bad_type}`) are still caught and surfaced correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # YARD-Lint Changelog
 
 ## 1.5.2 (Unreleased)
-- **[Fix]** `Tags/InvalidTypes` no longer false-positives on YARD pseudo-types `undefined`, `unspecified`, and `unknown` (#152)
+- **[Fix]** `Tags/InvalidTypes` no longer reports false positives for YARD pseudo-types `undefined`, `unspecified`, and `unknown` (#152)
   - These lowercase pseudo-types are used in real-world YARD docs (e.g. Solargraph uses `Hash{String => undefined}` extensively) to signal that a type is intentionally unspecified
   - They are now treated as valid types alongside the existing `nil`, `void`, `self`, `true`, `false` defaults
-- **[Fix]** `Tags/InvalidTypes` no longer false-positives on string literal hash keys (e.g. `Hash{"to" => String}`) (#152)
+- **[Fix]** `Tags/InvalidTypes` no longer reports false positives for string literal hash keys (e.g. `Hash{"to" => String}`) (#152)
   - String literal keys like `"email"` or `"name"` are valid YARD hash key notation and are now treated as valid alongside the existing symbol literal support (`:key`)
-- **[Fix]** `Tags/InvalidTypes` no longer false-positives on nested `Hash{K => V}` types (#151, #152)
+- **[Fix]** `Tags/InvalidTypes` no longer reports false positives for nested `Hash{K => V}` types (#151, #152)
   - Complex hash types such as `Hash{String => Hash{Symbol => Array<String>}}` were occasionally flagged as invalid; the `extract_type_names` splitter already handled them correctly after the 1.5.2 sanitizer rewrite, and regression tests now lock that behaviour in
   - Invalid types genuinely nested inside hash values (e.g. `Hash{String => bad_type}`) are still caught and surfaced correctly
 - **[Enhancement]** `Tags/InvalidTypes` offense messages now name the invalid type(s) and the tag they appear in (#151)

--- a/lib/yard/lint/validators/tags/invalid_types/validator.rb
+++ b/lib/yard/lint/validators/tags/invalid_types/validator.rb
@@ -19,6 +19,9 @@ module Yard
               nil
               self
               void
+              undefined
+              unspecified
+              unknown
             ].freeze
 
             private_constant :ALLOWED_DEFAULTS

--- a/lib/yard/lint/validators/tags/invalid_types/validator.rb
+++ b/lib/yard/lint/validators/tags/invalid_types/validator.rb
@@ -75,9 +75,8 @@ module Yard
             # @param type [String] type name to check
             # @return [Boolean] true if type is defined (or at least recognized as a valid type)
             def type_defined?(type)
-              # Symbol types like :foo are valid YARD documentation notations
-              # They document that a method accepts specific symbol values
-              return true if type.start_with?(':')
+              # Symbol and string literal types (:foo, "bar") are valid hash key notations
+              return true if type.start_with?(':', '"', "'")
 
               # Check Ruby runtime first
               # The shell query uses: !(Kernel.const_defined?(type) rescue nil).nil?

--- a/test/fixtures/invalid_types_messages.rb
+++ b/test/fixtures/invalid_types_messages.rb
@@ -30,4 +30,21 @@ class InvalidTypesMessages
   # Invalid: bad type nested inside a hash value should still be caught.
   # @return [Hash{String => bad_nested_type}] hash with invalid value type
   def hash_with_invalid_value; end
+
+  # Valid: YARD pseudo-types used as hash values must not produce false positives.
+  # @return [Hash{String => undefined}] undefined is a YARD pseudo-type
+  def hash_with_undefined_value; end
+
+  # @return [Hash{String => unspecified}] unspecified is a YARD pseudo-type
+  def hash_with_unspecified_value; end
+
+  # @return [Hash{String => unknown}] unknown is a YARD pseudo-type
+  def hash_with_unknown_value; end
+
+  # @return [Hash{String => Array<Hash{String => undefined}>}] nested with undefined
+  def hash_nested_with_undefined; end
+
+  # Valid: undefined as a standalone return type
+  # @return [undefined] raw pseudo-type (not in hash)
+  def standalone_undefined; end
 end

--- a/test/fixtures/invalid_types_messages.rb
+++ b/test/fixtures/invalid_types_messages.rb
@@ -47,4 +47,11 @@ class InvalidTypesMessages
   # Valid: undefined as a standalone return type
   # @return [undefined] raw pseudo-type (not in hash)
   def standalone_undefined; end
+
+  # Valid: string literal keys in Hash types must not produce false positives.
+  # @return [Hash{"to" => Array<Hash{"email", "name" => String}>}] string key hash
+  def hash_with_string_keys; end
+
+  # @return [Hash{"subject" => String, "htmlContent" => String}] multiple string keys
+  def hash_with_multiple_string_keys; end
 end

--- a/test/integrations/invalid_types_messages_test.rb
+++ b/test/integrations/invalid_types_messages_test.rb
@@ -98,4 +98,46 @@ describe 'InvalidTypes offense messages' do
     refute_nil(offense)
     assert_includes(offense[:message], 'bad_nested_type')
   end
+
+  # -- YARD pseudo-types: undefined, unspecified, unknown --
+
+  it 'does not flag Hash with undefined value type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_with_undefined_value') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag Hash with unspecified value type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_with_unspecified_value') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag Hash with unknown value type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_with_unknown_value') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag deeply nested Hash containing undefined' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_nested_with_undefined') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag standalone undefined return type' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('standalone_undefined') }
+
+    assert_nil(offense)
+  end
 end

--- a/test/integrations/invalid_types_messages_test.rb
+++ b/test/integrations/invalid_types_messages_test.rb
@@ -140,4 +140,22 @@ describe 'InvalidTypes offense messages' do
 
     assert_nil(offense)
   end
+
+  # -- String literal hash keys --
+
+  it 'does not flag Hash with string literal keys' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_with_string_keys') }
+
+    assert_nil(offense)
+  end
+
+  it 'does not flag Hash with multiple string literal keys' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('hash_with_multiple_string_keys') }
+
+    assert_nil(offense)
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `undefined`, `unspecified`, and `unknown` to `ALLOWED_DEFAULTS` in `Tags/InvalidTypes`
- Real-world YARD docs (e.g. Solargraph) use these lowercase pseudo-types to signal an intentionally unspecified type — common in `Hash{String => undefined}` patterns
- Treats string literal hash keys (`"foo"`, `'foo'`) as valid, mirroring existing symbol literal support (`:foo`) — fixes false positives on e.g. `Hash{"to" => Array<Hash{"email" => String}>}`
- 7 new integration tests covering each pseudo-type, deeply nested pseudo-types, and string-literal hash keys

## Test plan

- [ ] `bundle exec rake test` — all tests pass including 7 new cases
- [ ] `Hash{String => undefined}` no longer produces an `InvalidTagType` offense
- [ ] `Hash{String => unspecified}` no longer produces an `InvalidTagType` offense
- [ ] `Hash{String => unknown}` no longer produces an `InvalidTagType` offense
- [ ] `Hash{String => Array<Hash{String => undefined}>}` (deeply nested) no longer flagged
- [ ] `standalone undefined` return type no longer flagged
- [ ] `Hash{"to" => Array<Hash{"email", "name" => String}>}` no longer flagged
- [ ] `Hash{"subject" => String, "htmlContent" => String}` no longer flagged
- [ ] Genuinely invalid lowercase types (e.g. `bad_type`) are still flagged correctly