### PR TITLE
test: integration coverage for ExtraTypes config in Tags/InvalidTypes

### DIFF
--- a/test/fixtures/extra_types.rb
+++ b/test/fixtures/extra_types.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Fixture for ExtraTypes integration tests.
+# These methods use non-standard lowercase type names that are NOT valid Ruby
+# constants and are NOT in ALLOWED_DEFAULTS — they would normally produce
+# InvalidTagType offenses. With ExtraTypes configured, they should be accepted.
+#
+# Note: uppercase type names (e.g. Callable, Result) are NOT flagged by default
+# because Kernel.const_defined? returns false (not nil) for syntactically valid
+# constant names, which yard-lint treats as "at least recognised". Only lowercase
+# names that raise NameError (e.g. generic, callable_type) are flagged.
+
+class ExtraTypes
+  # Solargraph-style generic type parameters (YARD proposal: lsegal/yard#1683).
+  # @param store [Hash{Class<generic<T>> => Set<generic<T>>}] generic type map
+  # @return [Array<generic<T>>] generic collection
+  def generic_types(store); end
+
+  # @return [generic<T>] standalone generic type parameter
+  def standalone_generic; end
+
+  # Multiple custom lowercase pseudo-types.
+  # @param handler [generic, awaitable] multiple non-standard types
+  def multiple_custom(handler); end
+end

--- a/test/integrations/extra_types_test.rb
+++ b/test/integrations/extra_types_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# Integration tests for the ExtraTypes configuration option in Tags/InvalidTypes.
+# ExtraTypes lets users declare non-standard type names (e.g. Solargraph's
+# `generic` type-parameter notation) so that yard-lint does not report them
+# as InvalidTagType offenses.
+#
+# Only lowercase tokens that raise NameError in Kernel.const_defined? are flagged
+# by default; uppercase names like `Callable` are treated as syntactically valid
+# constant names and are not flagged regardless of ExtraTypes.
+describe 'Tags/InvalidTypes ExtraTypes configuration' do
+  attr_reader :fixture_path
+
+  before do
+    @fixture_path = File.expand_path('../fixtures/extra_types.rb', __dir__)
+  end
+
+  # -- Without ExtraTypes: non-standard lowercase types ARE flagged --
+
+  it 'flags generic type without ExtraTypes configured' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InvalidTypes', 'Enabled', true)
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('generic_types') }
+
+    refute_nil(offense, 'generic type should be flagged when not in ExtraTypes')
+    assert_includes(offense[:message], 'generic')
+  end
+
+  it 'flags standalone generic return type without ExtraTypes configured' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InvalidTypes', 'Enabled', true)
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('standalone_generic') }
+
+    refute_nil(offense, 'generic<T> return type should be flagged when not in ExtraTypes')
+  end
+
+  # -- With ExtraTypes: configured types are accepted --
+
+  it 'does not flag generic type when added to ExtraTypes' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InvalidTypes', 'Enabled', true)
+      c.set_validator_config('Tags/InvalidTypes', 'ExtraTypes', ['generic'])
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('generic_types') }
+
+    assert_nil(offense, 'generic should not be flagged when listed in ExtraTypes')
+  end
+
+  it 'does not flag standalone generic return type when added to ExtraTypes' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InvalidTypes', 'Enabled', true)
+      c.set_validator_config('Tags/InvalidTypes', 'ExtraTypes', ['generic'])
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('standalone_generic') }
+
+    assert_nil(offense, 'generic<T> return type should not be flagged when generic is in ExtraTypes')
+  end
+
+  it 'does not flag any offense when all custom types are added to ExtraTypes' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InvalidTypes', 'Enabled', true)
+      c.set_validator_config('Tags/InvalidTypes', 'ExtraTypes', %w[generic awaitable])
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    offenses = result.offenses.select { |o| o[:name] == 'InvalidTagType' }
+
+    assert_empty(offenses, "Expected no InvalidTagType offenses but got: #{offenses.map { |o| o[:message] }}")
+  end
+
+  it 'only suppresses the listed ExtraTypes and still flags others' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InvalidTypes', 'Enabled', true)
+      # Only add generic — awaitable should still be flagged
+      c.set_validator_config('Tags/InvalidTypes', 'ExtraTypes', ['generic'])
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    # generic is suppressed across all methods that use it
+    generic_types_offense = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('generic_types') }
+    standalone_offense    = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('standalone_generic') }
+    # awaitable is not in ExtraTypes — still flagged
+    multiple_offense      = result.offenses.find { |o| o[:name] == 'InvalidTagType' && o[:message].include?('multiple_custom') }
+
+    assert_nil(generic_types_offense, 'generic should not be flagged when in ExtraTypes')
+    assert_nil(standalone_offense,    'standalone generic should not be flagged when in ExtraTypes')
+    refute_nil(multiple_offense,      'awaitable should still be flagged when not in ExtraTypes')
+    assert_includes(multiple_offense[:message], 'awaitable')
+  end
+end


### PR DESCRIPTION
## Summary

- Adds integration tests and fixture for the `ExtraTypes` configuration option in `Tags/InvalidTypes`
- Covers the Solargraph `generic` type-parameter use case (see [lsegal/yard#1683](https://github.com/lsegal/yard/issues/1683) and #152)
- Verifies that `ExtraTypes: [generic]` suppresses false positives while unlisted non-standard types are still flagged

## What is tested

- Without `ExtraTypes`: lowercase non-standard type names (e.g. `generic`) ARE flagged
- With `ExtraTypes: [generic]`: no offense produced for that type
- Partial `ExtraTypes`: only listed types are suppressed; others remain flagged
- All types listed: clean run with zero offenses

## Note on uppercase types

Uppercase custom type names (e.g. `Callable`, `Result`) are NOT flagged by default because `Kernel.const_defined?` returns `false` (not `nil`) for syntactically valid constant names — this is intentional behaviour that allows common informal types like `Boolean` to pass. Only lowercase tokens (like `generic`, `awaitable`) actually need `ExtraTypes` to be suppressed.

## Test plan

- [ ] `bundle exec rake test` — all 1885 tests pass