### PR TITLE
feat: add validator field to offense hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # YARD-Lint Changelog
 
 ## Unreleased
+- **[Enhancement]** Each offense now includes a `validator` field with the full config key (e.g. `"Documentation/MissingReturn"`, `"Tags/Order"`) identifying which validator produced it. The text formatter also now displays this path instead of the short offense name, making it easier to locate the right `.yard-lint.yml` setting to adjust.
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers
 - **[Fix]** Use `remove_method` instead of `define_singleton_method` to restore `warn` in `InProcessRegistry#capture_warnings`, eliminating a spurious method redefinition warning
 

--- a/bin/yard-lint
+++ b/bin/yard-lint
@@ -314,7 +314,7 @@ when 'text', nil
                           end
 
         puts "[#{severity_symbol}] #{offense[:location]}:#{offense[:location_line]}"
-        puts "    #{offense[:name]}: #{offense[:message]}"
+        puts "    #{offense[:validator]}: #{offense[:message]}"
         puts
       end
     end

--- a/lib/yard/lint/results/base.rb
+++ b/lib/yard/lint/results/base.rb
@@ -96,6 +96,8 @@ module Yard
         # @return [String] validator name for config lookup
         def validator_name
           # Extract from class path: Validators::Tags::Order::Result => 'Tags/Order'
+          return '' unless self.class.name
+
           parts = self.class.name.split('::')
           validators_index = parts.index('Validators')
           return '' unless validators_index
@@ -125,6 +127,7 @@ module Yard
               severity: configured_severity,
               type: self.class.offense_type,
               name: computed_offense_name,
+              validator: validator_name,
               message: build_message(offense_data),
               location: offense_data[:location] || offense_data[:file],
               location_line: offense_data[:line] || offense_data[:location_line] || 0

--- a/test/integrations/yard_lint_integration_test.rb
+++ b/test/integrations/yard_lint_integration_test.rb
@@ -316,6 +316,7 @@ describe 'Yard Lint Integration' do
       assert(offense.key?(:severity))
       assert(offense.key?(:type))
       assert(offense.key?(:name))
+      assert(offense.key?(:validator))
       assert(offense.key?(:message))
       assert(offense.key?(:location))
       assert(offense.key?(:location_line))

--- a/test/yard/lint/results/base_test.rb
+++ b/test/yard/lint/results/base_test.rb
@@ -59,9 +59,15 @@ describe 'Yard::Lint::Results::Base' do
     assert(offense.key?(:severity))
     assert(offense.key?(:type))
     assert(offense.key?(:name))
+    assert(offense.key?(:validator))
     assert(offense.key?(:message))
     assert(offense.key?(:location))
     assert(offense.key?(:location_line))
+  end
+
+  it 'offenses includes validator name in each offense' do
+    result = @test_result_class.new(@parsed_data, nil)
+    assert_equal('Tags/TestValidator', result.offenses.first[:validator])
   end
 
   it 'offenses uses default severity when no config' do

--- a/test/yard/lint/validators/tags/redundant_param_description/result_test.rb
+++ b/test/yard/lint/validators/tags/redundant_param_description/result_test.rb
@@ -282,6 +282,7 @@ describe 'Yard::Lint::Validators::Tags::RedundantParamDescription::Result' do
     offense = result.offenses.first
 
     assert(offense.key?(:name))
+    assert(offense.key?(:validator))
     assert(offense.key?(:location))
     assert(offense.key?(:location_line))
     assert(offense.key?(:severity))


### PR DESCRIPTION
## Summary

- Each offense now includes a `validator` field with the full config key (e.g. `"Documentation/MissingReturn"`, `"Tags/Order"`) identifying which validator produced it
- The text formatter now shows this path instead of the short offense name, so users can immediately copy the value into `.yard-lint.yml` to configure or disable a rule
- JSON output gains the field automatically — purely additive, no existing keys removed or renamed
- Fixes a latent `NoMethodError` in `validator_name` when called on anonymous result subclasses (nil `class.name`)

Inspired by the concept in Sorbet's [Add "source" to LSP Diagnostic instances](https://github.com/sorbet/sorbet/pull/10153) — the `validator` field serves the same purpose: making the origin of each diagnostic immediately actionable.

**Before:**
```
[W] lib/foo.rb:10
    MissingReturn: Missing @return tag for `Foo#bar`
```

**After:**
```
[W] lib/foo.rb:10
    Documentation/MissingReturn: Missing @return tag for `Foo#bar`
```

## Test plan

- [x] `test/yard/lint/results/base_test.rb` — new assertion that `offense[:validator]` equals the expected config path; existing key-presence assertions updated to include `:validator`
- [x] `test/integrations/yard_lint_integration_test.rb` — required offense keys check updated
- [x] `test/yard/lint/validators/tags/redundant_param_description/result_test.rb` — offense structure check updated
- [x] Full test suite passes: `1886 runs, 4226 assertions, 0 failures, 0 errors, 0 skips`