### PR TITLE
docs: document OrphanedDocComment validator and validator field in offense output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Accurate documentation isn't just for human developers anymore. [Research shows]
 
 YARD-Lint validates your YARD documentation for:
 
-- **Documentation Completeness** - Undocumented classes, modules, methods, parameters, boolean return values, and missing `@return` tags
+- **Documentation Completeness** - Undocumented classes, modules, methods, parameters, boolean return values, and missing `@return` tags; orphaned doc comments with YARD tags that YARD silently drops
 - **Type Accuracy** - Invalid type definitions, malformed type syntax, non-ASCII characters in types, tuple types, and literal types (symbols, strings, numbers)
 - **Tag Validation** - Incorrect tag ordering, meaningless tags, invalid tag positions, unknown tags with suggestions, forbidden tag patterns
 - **Code Examples** - Syntax validation in `@example` tags, optional style validation with RuboCop/StandardRB
@@ -225,6 +225,30 @@ Tags/ExampleStyle:
 
 **Learn more:** [Complete Configuration Guide](https://github.com/mensfeld/yard-lint/wiki/Configuration)
 
+## Catching Orphaned Documentation Comments
+
+YARD silently ignores comment blocks that contain YARD tags (`@param`, `@return`, etc.) when they are not immediately followed by a documentable construct (method, class, module, attribute). This happens with variable assignments, `require` calls, `include`/`extend` statements, or comments at the end of a file - the documentation is simply lost with no warning.
+
+The `Documentation/OrphanedDocComment` validator (enabled by default) catches this:
+
+```ruby
+# Bad - YARD drops this silently, @return is never attached
+# @param name [String] the name
+# @return [void]
+MY_CONSTANT = "value"
+
+# Bad - orphaned at end of file
+# @param id [Integer] user id
+# @return [User]
+
+# Good - properly attached to a method
+# @param name [String] the name
+# @return [void]
+def greet(name); end
+```
+
+This validator is complementary to `Documentation/BlankLineBeforeDefinition` (which handles the case where blank lines separate a doc comment from a `def` - YARD still attaches it despite the gap).
+
 ## Handling Non-Standard Types
 
 By default `Tags/InvalidTypes` accepts all built-in Ruby classes, constants, and a set of YARD pseudo-types (`nil`, `true`, `false`, `self`, `void`, `undefined`, `unspecified`, `unknown`). If your project uses additional type names that are not real Ruby classes - project-specific aliases, LSP extensions, or informal conventions - you can declare them via `ExtraTypes` so yard-lint does not report them as `InvalidTagType` offenses.
@@ -351,6 +375,23 @@ Information:
 ```
 
 **Learn more:** [Advanced Usage](https://github.com/mensfeld/yard-lint/wiki/Advanced-Usage) - CLI reference, JSON output, coverage
+
+## Offense Structure
+
+Every offense (in both text and JSON output) includes a `validator` field with the full config key that produced it, making it easy to find the right `.yard-lint.yml` setting to adjust:
+
+```json
+{
+  "name": "OrphanedDocComment",
+  "validator": "Documentation/OrphanedDocComment",
+  "severity": "warning",
+  "message": "Documentation comment with @param, @return tags is orphaned - YARD will ignore it",
+  "location": "lib/my_class.rb:42",
+  "location_line": 42
+}
+```
+
+The text formatter also shows the validator path (e.g., `[Documentation/OrphanedDocComment]`) instead of just the short offense name.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -227,15 +227,20 @@ Tags/ExampleStyle:
 
 ## Catching Orphaned Documentation Comments
 
-YARD silently ignores comment blocks that contain YARD tags (`@param`, `@return`, etc.) when they are not immediately followed by a documentable construct (method, class, module, attribute). This happens with variable assignments, `require` calls, `include`/`extend` statements, or comments at the end of a file - the documentation is simply lost with no warning.
+YARD silently ignores comment blocks that contain YARD tags (`@param`, `@return`, etc.) when they are not immediately followed by a documentable construct (method, class, module, constant, attribute). This happens with local variable assignments, `require` calls, `include`/`extend` statements, bare `private`/`public` keywords, or comments at the end of a file - the documentation is simply lost with no warning.
 
 The `Documentation/OrphanedDocComment` validator (enabled by default) catches this:
 
 ```ruby
-# Bad - YARD drops this silently, @return is never attached
+# Bad - YARD drops this silently; local variable is not documentable
 # @param name [String] the name
 # @return [void]
-MY_CONSTANT = "value"
+local_var = "value"
+
+# Bad - require is not documentable
+# @param id [Integer] user id
+# @return [User]
+require 'some_gem'
 
 # Bad - orphaned at end of file
 # @param id [Integer] user id
@@ -245,6 +250,10 @@ MY_CONSTANT = "value"
 # @param name [String] the name
 # @return [void]
 def greet(name); end
+
+# Good - constant assignments are documentable, not flagged
+# @return [Integer] the answer
+ANSWER = 42
 ```
 
 This validator is complementary to `Documentation/BlankLineBeforeDefinition` (which handles the case where blank lines separate a doc comment from a `def` - YARD still attaches it despite the gap).
@@ -385,8 +394,8 @@ Every offense (in both text and JSON output) includes a `validator` field with t
   "name": "OrphanedDocComment",
   "validator": "Documentation/OrphanedDocComment",
   "severity": "warning",
-  "message": "Documentation comment with @param, @return tags is orphaned - YARD will ignore it",
-  "location": "lib/my_class.rb:42",
+  "message": "Documentation comment with @param, @return is orphaned - YARD will ignore it",
+  "location": "lib/my_class.rb",
   "location_line": 42
 }
 ```


### PR DESCRIPTION
## Summary

- Adds `Documentation/OrphanedDocComment` to the Features Overview bullet and a new dedicated section explaining the silent-drop behaviour it detects (YARD silently ignores tagged comment blocks not attached to a documentable construct)
- Adds an **Offense Structure** section documenting the `validator` field (added in #164) that every offense hash now carries, with a JSON example showing the full structure

## What was missing

PR #165 added the `OrphanedDocComment` validator and PR #164 added the `validator` field to offense hashes, but neither was reflected in the README.