### PR TITLE
feat: add Tags/MissingYield opt-in validator

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -127,7 +127,7 @@ Tags/MeaninglessTag:
     - constant
 
 Tags/MissingYield:
-  Description: 'Detects methods that yield to a block without a @yield tag.'
+  Description: 'Detects methods that yield to a block without a @yield, @yieldparam, or @yieldreturn tag.'
   Enabled: false  # Opt-in validator
   Severity: warning
 

--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -126,6 +126,11 @@ Tags/MeaninglessTag:
     - module
     - constant
 
+Tags/MissingYield:
+  Description: 'Detects methods that yield to a block without a @yield tag.'
+  Enabled: false  # Opt-in validator
+  Severity: warning
+
 Tags/CollectionType:
   Description: 'Validates Hash collection syntax consistency.'
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # YARD-Lint Changelog
 
 ## 1.6.0 (Unreleased)
+- **[Feature]** New opt-in validator `Tags/MissingYield` detects methods that call `yield` in their body but do not document the block with a `@yield`, `@yieldparam`, or `@yieldreturn` tag. Callers need to know a method yields in order to pass a block; the validator checks raw docstring text rather than YARD's inferred tag list, so YARD's automatic `@yield` inference for bare `yield expr` statements does not suppress the offense. Method calls like `Fiber.yield` and `yielder.yield` are not flagged. Disabled by default - enable with `Tags/MissingYield: Enabled: true`.
 - **[Feature]** New validator `Documentation/OrphanedDocComment` detects YARD comment blocks with tags (`@param`, `@return`, etc.) that are not attached to any documentable Ruby construct and will be silently dropped by YARD. Triggered when a tagged comment is immediately followed by a non-documentable statement (variable assignment, `require`, `include`, etc.) or sits at end-of-file. Enabled by default. Complementary to `Documentation/BlankLineBeforeDefinition` which handles the blank-lines-before-def case.
 - **[Enhancement]** Each offense now includes a `validator` field with the full config key (e.g. `"Documentation/MissingReturn"`, `"Tags/Order"`) identifying which validator produced it. The text formatter also now displays this path instead of the short offense name, making it easier to locate the right `.yard-lint.yml` setting to adjust.
 - **[Enhancement]** Add Ruby warning category opt-in to test helpers

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ YARD-Lint validates your YARD documentation for:
 
 - **Documentation Completeness** - Undocumented classes, modules, methods, parameters, boolean return values, and missing `@return` tags; orphaned doc comments with YARD tags that YARD silently drops
 - **Type Accuracy** - Invalid type definitions, malformed type syntax, non-ASCII characters in types, tuple types, and literal types (symbols, strings, numbers)
-- **Tag Validation** - Incorrect tag ordering, meaningless tags, invalid tag positions, unknown tags with suggestions, forbidden tag patterns
+- **Tag Validation** - Incorrect tag ordering, meaningless tags, invalid tag positions, unknown tags with suggestions, forbidden tag patterns, undocumented `yield` calls (opt-in)
 - **Code Examples** - Syntax validation in `@example` tags, optional style validation with RuboCop/StandardRB
 - **Semantic Correctness** - Abstract methods with implementations, redundant descriptions
 - **Style & Formatting** - Empty comment lines, blank lines before definitions, informal notation patterns, tag group separators
@@ -30,7 +30,7 @@ YARD-Lint validates your YARD documentation for:
 - **Performance** - In-process YARD execution with shared registry (~10x faster than shell-based execution)
 - **Incremental Adoption** - `--auto-gen-config` generates a baseline todo file to adopt on legacy codebases without fixing everything first
 
-**See the complete list:** [All Features](https://github.com/mensfeld/yard-lint/wiki/Features) | [30 Validators](https://github.com/mensfeld/yard-lint/wiki/Validators)
+**See the complete list:** [All Features](https://github.com/mensfeld/yard-lint/wiki/Features) | [31 Validators](https://github.com/mensfeld/yard-lint/wiki/Validators)
 
 ## Installation
 
@@ -257,6 +257,42 @@ ANSWER = 42
 ```
 
 This validator is complementary to `Documentation/BlankLineBeforeDefinition` (which handles the case where blank lines separate a doc comment from a `def` - YARD still attaches it despite the gap).
+
+## Documenting yield (opt-in)
+
+The `Tags/MissingYield` validator (opt-in, disabled by default) detects methods that call `yield` in their body but do not document the block with a `@yield`, `@yieldparam`, or `@yieldreturn` tag. Callers need to know a method yields in order to pass a block.
+
+Enable it in `.yard-lint.yml`:
+
+```yaml
+Tags/MissingYield:
+  Enabled: true
+  Severity: warning
+```
+
+```ruby
+# Bad - method yields but block is not documented
+# @param items [Array] the items to process
+def each(items)
+  items.each { |item| yield item }
+end
+
+# Good - block documented with @yield
+# @param items [Array] the items to process
+# @yield [item] each item in the collection
+def each(items)
+  items.each { |item| yield item }
+end
+
+# Good - @yieldparam is also accepted
+# @param items [Array] the items to process
+# @yieldparam item [Object] each item
+def each(items)
+  items.each { |item| yield item }
+end
+```
+
+Method calls like `Fiber.yield` and `yielder.yield` (Enumerator::Yielder) are not flagged - only the `yield` keyword triggers the check.
 
 ## Handling Non-Standard Types
 

--- a/lib/yard/lint/templates/default_config.yml
+++ b/lib/yard/lint/templates/default_config.yml
@@ -137,7 +137,7 @@ Tags/MeaninglessTag:
     - constant
 
 Tags/MissingYield:
-  Description: 'Detects methods that yield to a block without a @yield tag.'
+  Description: 'Detects methods that yield to a block without a @yield, @yieldparam, or @yieldreturn tag.'
   Enabled: false  # Opt-in validator
   Severity: warning
 

--- a/lib/yard/lint/templates/default_config.yml
+++ b/lib/yard/lint/templates/default_config.yml
@@ -136,6 +136,11 @@ Tags/MeaninglessTag:
     - module
     - constant
 
+Tags/MissingYield:
+  Description: 'Detects methods that yield to a block without a @yield tag.'
+  Enabled: false  # Opt-in validator
+  Severity: warning
+
 Tags/CollectionType:
   Description: 'Validates Hash collection syntax consistency.'
   Enabled: true

--- a/lib/yard/lint/templates/strict_config.yml
+++ b/lib/yard/lint/templates/strict_config.yml
@@ -140,6 +140,11 @@ Tags/MeaninglessTag:
     - module
     - constant
 
+Tags/MissingYield:
+  Description: 'Detects methods that yield to a block without a @yield tag.'
+  Enabled: true  # Enabled in strict mode
+  Severity: error
+
 Tags/CollectionType:
   Description: 'Validates Hash collection syntax consistency.'
   Enabled: true

--- a/lib/yard/lint/templates/strict_config.yml
+++ b/lib/yard/lint/templates/strict_config.yml
@@ -141,7 +141,7 @@ Tags/MeaninglessTag:
     - constant
 
 Tags/MissingYield:
-  Description: 'Detects methods that yield to a block without a @yield tag.'
+  Description: 'Detects methods that yield to a block without a @yield, @yieldparam, or @yieldreturn tag.'
   Enabled: true  # Enabled in strict mode
   Severity: error
 

--- a/lib/yard/lint/validators/tags/missing_yield.rb
+++ b/lib/yard/lint/validators/tags/missing_yield.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Tags
+        # MissingYield validator
+        #
+        # Detects methods that call `yield` in their body but do not document
+        # the block with a `@yield`, `@yieldparam`, or `@yieldreturn` tag.
+        # Callers need to know a method yields so they can pass a block;
+        # undocumented yield is a silent API contract that only source readers
+        # discover.
+        #
+        # This validator is disabled by default (opt-in).
+        #
+        # @note Does not flag the inverse case (has `@yield` tag but no actual
+        #   `yield` in source) - that is intentional for abstract/overridable methods.
+        #
+        # @note Known limitation: `yield` appearing inside heredoc bodies or
+        #   multi-line string literals may produce false positives. These cases
+        #   are rare enough in practice that the validator does not attempt to
+        #   handle them.
+        #
+        # @example Bad - method yields but block is undocumented
+        #   # Iterates over items
+        #   # @param items [Array] the items
+        #   def each(items)
+        #     items.each { |item| yield item }
+        #   end
+        #
+        # @example Good - block documented with @yield
+        #   # Iterates over items
+        #   # @param items [Array] the items
+        #   # @yield [item] each item in the collection
+        #   def each(items)
+        #     items.each { |item| yield item }
+        #   end
+        #
+        # @example Good - block documented with @yieldparam
+        #   # @param items [Array] the items
+        #   # @yieldparam item [Object] each item
+        #   def each(items)
+        #     items.each { |item| yield item }
+        #   end
+        #
+        # ## Configuration
+        #
+        #     Tags/MissingYield:
+        #       Enabled: true
+        #       Severity: warning
+        module MissingYield
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/tags/missing_yield/config.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/config.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Tags
+        module MissingYield
+          # Configuration for MissingYield validator
+          class Config < ::Yard::Lint::Validators::Config
+            self.id = :missing_yield
+            self.defaults = {
+              'Enabled' => false,
+              'Severity' => 'warning'
+            }.freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/tags/missing_yield/messages_builder.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/messages_builder.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Tags
+        module MissingYield
+          # Builds messages for missing yield tag offenses
+          class MessagesBuilder
+            class << self
+              # @param offense [Hash] offense data with :element key
+              # @return [String] formatted message
+              def call(offense)
+                "Method `#{offense[:element]}` yields to a block but is missing a @yield tag"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/tags/missing_yield/messages_builder.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/messages_builder.rb
@@ -11,7 +11,7 @@ module Yard
               # @param offense [Hash] offense data with :element key
               # @return [String] formatted message
               def call(offense)
-                "Method `#{offense[:element]}` yields to a block but is missing a @yield tag"
+                "Method `#{offense[:element]}` yields to a block but is missing a @yield, @yieldparam, or @yieldreturn tag"
               end
             end
           end

--- a/lib/yard/lint/validators/tags/missing_yield/parser.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/parser.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Tags
+        module MissingYield
+          # Parses validator output into structured offense hashes.
+          # @example Output format (one offense per line)
+          #   # "path/to/file.rb:10: ClassName#method_name"
+          class Parser < ::Yard::Lint::Parsers::Base
+            # @return [Regexp] parses "file:line: element" collector output lines
+            LINE_REGEX = /^(.+):(\d+): (.+)$/.freeze
+
+            # @param validator_output [String] raw collector output
+            # @param config [Yard::Lint::Config, nil] configuration (unused)
+            # @return [Array<Hash>] parsed offense hashes
+            def call(validator_output, config: nil)
+              validator_output
+                .split("\n")
+                .map(&:strip)
+                .reject(&:empty?)
+                .filter_map do |line|
+                  match = line.match(LINE_REGEX)
+                  next unless match
+
+                  {
+                    location: match[1],
+                    line: match[2].to_i,
+                    element: match[3]
+                  }
+                end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/tags/missing_yield/result.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/result.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Tags
+        module MissingYield
+          # Result object for missing yield tag validation
+          class Result < Results::Base
+            self.default_severity = 'warning'
+            self.offense_type = 'line'
+            self.offense_name = 'MissingYield'
+
+            # @param offense [Hash] offense data
+            # @return [String] formatted message
+            def build_message(offense)
+              MessagesBuilder.call(offense)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/tags/missing_yield/validator.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/validator.rb
@@ -14,8 +14,8 @@ module Yard
             # prevents matching method calls like `Fiber.yield` or `yielder.yield`
             # and symbol literals like `:yield`. Word boundaries ensure `yield_self`
             # and similar identifiers are not matched.
-            # Note: `yield` inside regex literals (e.g. /yield/) is a known
-            # limitation - it is rare enough in method bodies to be acceptable.
+            # Known limitation: `yield` inside regex literals (e.g. /yield/) is
+            # not stripped before scanning; it is rare enough to be acceptable.
             YIELD_PATTERN = /(?<![:.])\byield\b/.freeze
 
             # @return [Regexp] matches full-line Ruby comments

--- a/lib/yard/lint/validators/tags/missing_yield/validator.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/validator.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Tags
+        module MissingYield
+          # Detects methods that call `yield` but lack @yield/@yieldparam/@yieldreturn documentation
+          class Validator < Base
+            # Enable in-process execution with all visibility (private methods can yield too)
+            in_process visibility: :all
+
+            # Matches the `yield` keyword. The negative lookbehind `(?<!\.)` prevents
+            # matching method calls like `Fiber.yield` or `yielder.yield`. Word boundaries
+            # ensure `yield_self` and similar identifiers are not matched.
+            YIELD_PATTERN = /(?<!\.)\byield\b/.freeze
+
+            # @return [Regexp] matches full-line Ruby comments
+            COMMENT_LINE_PATTERN = /\A\s*#/.freeze
+
+            # Matches simple single- and double-quoted string literals to strip before
+            # scanning for the yield keyword, reducing false positives from strings
+            # that contain the word "yield".
+            STRING_LITERAL_PATTERN = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')/.freeze
+
+            # Matches user-written @yield, @yieldparam, or @yieldreturn tags in raw
+            # docstring text. YARD infers @yield automatically for bare `yield expr`
+            # statements and adds it to object.tags(), so we check docstring.all (the
+            # raw source text) rather than the parsed tag list to avoid counting
+            # YARD-inferred tags as explicit documentation.
+            YIELD_TAG_PATTERN = /^\s*@yield(?:param|return)?(?:\s|$)/.freeze
+
+            # Execute query for a single object during in-process execution.
+            # Flags methods that yield without a @yield, @yieldparam, or @yieldreturn tag.
+            # @param object [YARD::CodeObjects::Base] the code object to query
+            # @param collector [Executor::ResultCollector] collector for output
+            # @return [void]
+            def in_process_query(object, collector)
+              return unless object.type == :method
+              return if object.is_alias?
+              return unless object.is_explicit?
+              return unless object.source
+              return if yield_documented?(object)
+              return unless source_contains_yield?(object.source)
+
+              collector.puts "#{object.file}:#{object.line}: #{object.title}"
+            end
+
+            private
+
+            # @param object [YARD::CodeObjects::MethodObject] the method to check
+            # @return [Boolean] true if the user explicitly wrote a yield-related tag
+            def yield_documented?(object)
+              object.docstring.all.match?(YIELD_TAG_PATTERN)
+            end
+
+            # @param source [String] raw method source code
+            # @return [Boolean] true if the source contains the `yield` keyword
+            def source_contains_yield?(source)
+              source.each_line.any? do |line|
+                next false if line.match?(COMMENT_LINE_PATTERN)
+
+                sanitized = line.gsub(STRING_LITERAL_PATTERN, '""')
+                sanitized = sanitized.sub(/#.*$/, '')
+                sanitized.match?(YIELD_PATTERN)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/tags/missing_yield/validator.rb
+++ b/lib/yard/lint/validators/tags/missing_yield/validator.rb
@@ -10,10 +10,13 @@ module Yard
             # Enable in-process execution with all visibility (private methods can yield too)
             in_process visibility: :all
 
-            # Matches the `yield` keyword. The negative lookbehind `(?<!\.)` prevents
-            # matching method calls like `Fiber.yield` or `yielder.yield`. Word boundaries
-            # ensure `yield_self` and similar identifiers are not matched.
-            YIELD_PATTERN = /(?<!\.)\byield\b/.freeze
+            # Matches the `yield` keyword. The negative lookbehind `(?<![:.])`
+            # prevents matching method calls like `Fiber.yield` or `yielder.yield`
+            # and symbol literals like `:yield`. Word boundaries ensure `yield_self`
+            # and similar identifiers are not matched.
+            # Note: `yield` inside regex literals (e.g. /yield/) is a known
+            # limitation - it is rare enough in method bodies to be acceptable.
+            YIELD_PATTERN = /(?<![:.])\byield\b/.freeze
 
             # @return [Regexp] matches full-line Ruby comments
             COMMENT_LINE_PATTERN = /\A\s*#/.freeze

--- a/test/integrations/missing_yield_test.rb
+++ b/test/integrations/missing_yield_test.rb
@@ -1,0 +1,349 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+describe 'Tags/MissingYield' do
+  attr_reader :test_dir
+
+  before do
+    @test_dir = Dir.mktmpdir
+  end
+
+  after do
+    FileUtils.rm_rf(@test_dir) if @test_dir && File.exist?(@test_dir)
+  end
+
+  def create_test_file(filename, content)
+    path = File.join(@test_dir, filename)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  def enabled_config
+    Yard::Lint::Config.new do |c|
+      c.set_validator_config('Tags/MissingYield', 'Enabled', true)
+    end
+  end
+
+  def missing_yield_offenses(result)
+    result.offenses.select { |o| o[:name].to_s == 'MissingYield' }
+  end
+
+  # -- Opt-in behaviour --
+
+  it 'is disabled by default and reports no offenses without opt-in' do
+    config = Yard::Lint::Config.new
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @param items [Array] items
+        def each(items)
+          items.each { |item| yield item }
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: config, progress: false)
+    assert_empty(missing_yield_offenses(result), 'should be disabled by default')
+  end
+
+  # -- Core detection --
+
+  it 'flags a method that yields with no yield-related tag' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # Iterates over items.
+        # @param items [Array] the items
+        def each(items)
+          items.each { |item| yield item }
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    offenses = missing_yield_offenses(result)
+    refute_empty(offenses, 'method with yield and no @yield tag should be flagged')
+    assert_includes(offenses.first[:message], 'each')
+  end
+
+  it 'does not flag a method that yields when @yield tag is present' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # Iterates over items.
+        # @param items [Array] the items
+        # @yield [item] each item
+        def each(items)
+          items.each { |item| yield item }
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag a method when only @yieldparam is present' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @param items [Array] the items
+        # @yieldparam item [Object] each item yielded
+        def each(items)
+          items.each { |item| yield item }
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag a method when only @yieldreturn is present' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @param items [Array] the items
+        # @yieldreturn [void]
+        def each(items)
+          items.each { |item| yield item }
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag a method that has no yield at all' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @param x [Integer] a number
+        # @return [Integer] doubled value
+        def double(x)
+          x * 2
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  # -- yield keyword variants --
+
+  it 'flags yield with arguments (yield value)' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @param value [String] value
+        def wrap(value)
+          yield value
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    refute_empty(missing_yield_offenses(result))
+  end
+
+  it 'flags yield self' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # Taps self into a block.
+        def tap_self
+          yield self
+          self
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    refute_empty(missing_yield_offenses(result))
+  end
+
+  it 'flags return yield pattern' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # Delegates to block.
+        def delegate
+          return yield
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    refute_empty(missing_yield_offenses(result))
+  end
+
+  it 'flags conditional yield with block_given?' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # Optionally yields.
+        def maybe_yield(val)
+          yield val if block_given?
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    refute_empty(missing_yield_offenses(result))
+  end
+
+  # -- False positive guards --
+
+  it 'does not flag yield inside a comment line' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # This method does not yield - use yield in the caller instead.
+        # @return [String] result
+        def process
+          "done"
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag yield inside a double-quoted string literal' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @return [String] a message
+        def message
+          "please yield a block to this method"
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag yield inside a single-quoted string literal' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @return [String] a message
+        def message
+          'please yield a block'
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag Fiber.yield (method call, not keyword)' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @return [Object] fiber result
+        def run_fiber
+          Fiber.yield(42)
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag yielder.yield (Enumerator::Yielder method call)' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @return [Enumerator] lazy enumerator
+        def lazy_each
+          Enumerator.new do |y|
+            @items.each { |item| y.yield(item) }
+          end
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  it 'does not flag a method named yield_something (not the yield keyword)' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @return [void]
+        def yield_control
+          :noop
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  # -- Visibility --
+
+  it 'flags private methods that yield' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        private
+
+        # Helper that yields to a block.
+        def internal_each(items)
+          items.each { |i| yield i }
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    refute_empty(missing_yield_offenses(result))
+  end
+
+  # -- Alias / implicit method skip --
+
+  it 'does not flag alias methods' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # Iterates.
+        # @yield [item] each item
+        def each
+          yield 1
+        end
+
+        alias each_item each
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    # only `each` is flagged - `each_item` is an alias and should not be
+    # (each itself is documented so neither should be flagged)
+    assert_empty(missing_yield_offenses(result))
+  end
+
+  # -- Multiple methods --
+
+  it 'flags all methods missing @yield across multiple methods in a file' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # Processes items.
+        def process(items)
+          items.each { |i| yield i }
+        end
+
+        # Wraps a value.
+        def wrap(val)
+          yield val
+        end
+
+        # Already documented.
+        # @yield [x] the value
+        def documented(val)
+          yield val
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    offenses = missing_yield_offenses(result)
+    assert_equal(2, offenses.size,
+      "Expected 2 offenses but got #{offenses.size}: #{offenses.map { |o| o[:message] }}")
+    messages = offenses.map { |o| o[:message] }
+    assert(messages.any? { |m| m.include?('process') })
+    assert(messages.any? { |m| m.include?('wrap') })
+  end
+end

--- a/test/integrations/missing_yield_test.rb
+++ b/test/integrations/missing_yield_test.rb
@@ -232,6 +232,20 @@ describe 'Tags/MissingYield' do
     assert_empty(missing_yield_offenses(result))
   end
 
+  it 'does not flag :yield symbol literal' do
+    file = create_test_file('example.rb', <<~RUBY)
+      class Foo
+        # @return [Boolean] whether the method responds to yield
+        def supports_yield?
+          respond_to?(:yield)
+        end
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
+    assert_empty(missing_yield_offenses(result))
+  end
+
   it 'does not flag Fiber.yield (method call, not keyword)' do
     file = create_test_file('example.rb', <<~RUBY)
       class Foo
@@ -310,8 +324,8 @@ describe 'Tags/MissingYield' do
     RUBY
 
     result = Yard::Lint.run(path: file, config: enabled_config, progress: false)
-    # only `each` is flagged - `each_item` is an alias and should not be
-    # (each itself is documented so neither should be flagged)
+    # `each` is documented with @yield so no offense; `each_item` is an
+    # alias and is skipped regardless - neither should be flagged
     assert_empty(missing_yield_offenses(result))
   end
 


### PR DESCRIPTION
## Summary

- Adds `Tags/MissingYield` opt-in validator that flags methods calling `yield` without a `@yield`, `@yieldparam`, or `@yieldreturn` tag in their docstring
- Disabled by default; enabled in `strict_config.yml`
- 20 integration tests covering all edge cases

## Key implementation detail

YARD automatically infers a `@yield` tag for bare `yield expr` statements at the top level of a method body and adds it to `object.tags()`. This means checking `object.tag(:yield)` would incorrectly treat YARD-inferred tags as user documentation.

The validator checks `object.docstring.all` (the raw source text of the docstring) instead. If the user explicitly wrote `@yield`, `@yieldparam`, or `@yieldreturn`, it appears there. YARD's auto-inferred tags do not.

## False positive guards

- `Fiber.yield` and `yielder.yield` (method calls) excluded via `(?<!\.)` negative lookbehind
- `yield` inside string literals stripped before scanning
- `yield` inside comment lines skipped
- `yield_self` and similar identifiers not matched (word boundary)

## OSS validation

Tested against `rake`, `net-http`, and `csv` - all reported offenses are genuine undocumented yield calls with no false positives.