### PR TITLE
feat: add Documentation/TextSubstitution validator

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -83,6 +83,14 @@ Documentation/LineLength:
   Severity: convention
   MaxLength: 120
 
+Documentation/TextSubstitution:
+  Description: 'Detects forbidden characters or strings in documentation and suggests replacements.'
+  Enabled: false  # Opt-in validator
+  Severity: warning
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: 'Enforces consistent ordering of YARD tags.'

--- a/lib/yard/lint/templates/default_config.yml
+++ b/lib/yard/lint/templates/default_config.yml
@@ -108,6 +108,14 @@ Documentation/LineLength:
   Severity: convention
   MaxLength: 120
 
+Documentation/TextSubstitution:
+  Description: 'Detects forbidden characters or strings in documentation and suggests replacements.'
+  Enabled: false  # Opt-in validator
+  Severity: warning
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: 'Enforces consistent ordering of YARD tags.'

--- a/lib/yard/lint/templates/strict_config.yml
+++ b/lib/yard/lint/templates/strict_config.yml
@@ -112,6 +112,14 @@ Documentation/LineLength:
   Severity: error
   MaxLength: 120
 
+Documentation/TextSubstitution:
+  Description: 'Detects forbidden characters or strings in documentation and suggests replacements.'
+  Enabled: true
+  Severity: warning
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: 'Enforces consistent ordering of YARD tags.'

--- a/lib/yard/lint/validators/documentation/text_substitution.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        # TextSubstitution validator
+        #
+        # Detects forbidden characters or strings in YARD documentation comments
+        # and suggests replacements. The primary use case is detecting AI-generated
+        # em-dashes (—, U+2014) and en-dashes (–, U+2013) where a plain hyphen (-)
+        # is preferred, but any string-to-string substitution rule can be configured.
+        #
+        # All substitution rules are checked on every line — multiple violations can
+        # be reported for the same line when more than one forbidden string appears.
+        # Fenced code blocks (``` ... ```) are skipped.
+        #
+        # Disabled by default — enable it and configure Substitutions to taste.
+        #
+        # @example Bad - em-dash used in documentation
+        #   # Connects the start — and end of the range.
+        #   def connect(start, finish)
+        #   end
+        #
+        # @example Good - plain hyphen
+        #   # Connects the start - and end of the range.
+        #   def connect(start, finish)
+        #   end
+        #
+        # ## Configuration
+        #
+        # Enable with built-in defaults (em-dash and en-dash):
+        #
+        #     Documentation/TextSubstitution:
+        #       Enabled: true
+        #
+        # Enable with explicit substitution rules:
+        #
+        #     Documentation/TextSubstitution:
+        #       Enabled: true
+        #       Substitutions:
+        #         "—": "-"    # em-dash (U+2014)
+        #         "–": "-"    # en-dash (U+2013)
+        #         "…": "..."  # ellipsis (U+2026)
+        #
+        # To disable:
+        #
+        #     Documentation/TextSubstitution:
+        #       Enabled: false
+        module TextSubstitution
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/text_substitution/config.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/config.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module TextSubstitution
+          # Configuration for the TextSubstitution validator
+          class Config < ::Yard::Lint::Validators::Config
+            self.id = :text_substitution
+            self.defaults = {
+              'Enabled' => false,
+              'Severity' => 'warning',
+              'Substitutions' => {
+                "—" => '-', # em-dash (—)
+                "–" => '-'  # en-dash (–)
+              }
+            }.freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/text_substitution/messages_builder.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/messages_builder.rb
@@ -7,11 +7,9 @@ module Yard
         module TextSubstitution
           # Builds human-readable messages for TextSubstitution violations.
           class MessagesBuilder
-            TRUNCATE_AT = 60
-
             class << self
-              # @param offense [Hash]
-              # @return [String]
+              # @param offense [Hash] offense details with :forbidden, :replacement, :line_text keys
+              # @return [String] formatted message
               def call(offense)
                 forbidden   = offense[:forbidden]
                 replacement = offense[:replacement]
@@ -20,9 +18,7 @@ module Yard
                 message = "Replace '#{forbidden}' with '#{replacement}' in documentation"
 
                 if line_text && !line_text.empty?
-                  truncated = line_text.length > TRUNCATE_AT \
-                    ? "#{line_text[0, TRUNCATE_AT - 3]}..." \
-                    : line_text
+                  truncated = line_text.length > 60 ? "#{line_text[0, 57]}..." : line_text
                   message += ". Found: \"#{truncated}\""
                 end
 

--- a/lib/yard/lint/validators/documentation/text_substitution/messages_builder.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/messages_builder.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module TextSubstitution
+          # Builds human-readable messages for TextSubstitution violations.
+          class MessagesBuilder
+            TRUNCATE_AT = 60
+
+            class << self
+              # @param offense [Hash]
+              # @return [String]
+              def call(offense)
+                forbidden   = offense[:forbidden]
+                replacement = offense[:replacement]
+                line_text   = offense[:line_text]
+
+                message = "Replace '#{forbidden}' with '#{replacement}' in documentation"
+
+                if line_text && !line_text.empty?
+                  truncated = line_text.length > TRUNCATE_AT \
+                    ? "#{line_text[0, TRUNCATE_AT - 3]}..." \
+                    : line_text
+                  message += ". Found: \"#{truncated}\""
+                end
+
+                message
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/text_substitution/parser.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/parser.rb
@@ -11,8 +11,9 @@ module Yard
           #   file.rb:LINE: ObjectTitle
           #   forbidden|replacement|line_offset|line_text
           class Parser < ::Yard::Lint::Parsers::Base
-            # @param yard_output [String]
-            # @return [Array<Hash>]
+            # @param yard_output [String] raw collector output from the validator
+            # @option _kwargs [Object] :unused accepts no options (reserved for future use)
+            # @return [Array<Hash>] array with violation details
             def call(yard_output, **_kwargs)
               return [] if yard_output.nil? || yard_output.strip.empty?
 

--- a/lib/yard/lint/validators/documentation/text_substitution/parser.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/parser.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module TextSubstitution
+          # Parses TextSubstitution validator output into structured violation hashes.
+          #
+          # Wire format (two lines per violation):
+          #   file.rb:LINE: ObjectTitle
+          #   forbidden|replacement|line_offset|line_text
+          class Parser < ::Yard::Lint::Parsers::Base
+            # @param yard_output [String]
+            # @return [Array<Hash>]
+            def call(yard_output, **_kwargs)
+              return [] if yard_output.nil? || yard_output.strip.empty?
+
+              lines = yard_output.split("\n").map(&:strip).reject(&:empty?)
+              violations = []
+
+              lines.each_slice(2) do |location_line, details_line|
+                next unless location_line && details_line
+
+                location_match = location_line.match(/^(.+):(\d+): (.+)$/)
+                next unless location_match
+
+                # Limit to 4 parts so line_text may contain pipe characters
+                details = details_line.split('|', 4)
+                next unless details.size >= 3
+
+                forbidden, replacement, line_offset_str, line_text = details
+
+                violations << {
+                  location:    location_match[1],
+                  line:        location_match[2].to_i,
+                  object_name: location_match[3],
+                  forbidden:   forbidden,
+                  replacement: replacement,
+                  line_offset: line_offset_str.to_i,
+                  line_text:   line_text || ''
+                }
+              end
+
+              violations
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/text_substitution/parser.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/parser.rb
@@ -7,9 +7,14 @@ module Yard
         module TextSubstitution
           # Parses TextSubstitution validator output into structured violation hashes.
           #
-          # Wire format (two lines per violation):
+          # Wire format (four lines per violation):
           #   file.rb:LINE: ObjectTitle
-          #   forbidden|replacement|line_offset|line_text
+          #   forbidden
+          #   replacement
+          #   line_offset|line_text
+          #
+          # forbidden and replacement occupy their own lines so they may contain
+          # any character, including the pipe delimiter used in the last field.
           class Parser < ::Yard::Lint::Parsers::Base
             # @param yard_output [String] raw collector output from the validator
             # @option _kwargs [Object] :unused accepts no options (reserved for future use)
@@ -17,27 +22,26 @@ module Yard
             def call(yard_output, **_kwargs)
               return [] if yard_output.nil? || yard_output.strip.empty?
 
-              lines = yard_output.split("\n").map(&:strip).reject(&:empty?)
+              # Do not strip lines — forbidden/replacement may have significant whitespace
+              lines = yard_output.split("\n")
               violations = []
 
-              lines.each_slice(2) do |location_line, details_line|
-                next unless location_line && details_line
+              lines.each_slice(4) do |location_line, forbidden_line, replacement_line, details_line|
+                next unless location_line && forbidden_line && replacement_line && details_line
 
-                location_match = location_line.match(/^(.+):(\d+): (.+)$/)
+                location_match = location_line.strip.match(/^(.+):(\d+): (.+)$/)
                 next unless location_match
 
-                # Limit to 4 parts so line_text may contain pipe characters
-                details = details_line.split('|', 4)
-                next unless details.size >= 3
-
-                forbidden, replacement, line_offset_str, line_text = details
+                # line_offset is always numeric; split on first pipe only so line_text may contain pipes
+                line_offset_str, line_text = details_line.split('|', 2)
+                next unless line_offset_str
 
                 violations << {
                   location:    location_match[1],
                   line:        location_match[2].to_i,
                   object_name: location_match[3],
-                  forbidden:   forbidden,
-                  replacement: replacement,
+                  forbidden:   forbidden_line,
+                  replacement: replacement_line,
                   line_offset: line_offset_str.to_i,
                   line_text:   line_text || ''
                 }

--- a/lib/yard/lint/validators/documentation/text_substitution/result.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/result.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module TextSubstitution
+          # Result wrapper for TextSubstitution violations
+          class Result < Results::Base
+            self.default_severity = 'warning'
+            self.offense_type     = 'line'
+            self.offense_name     = 'TextSubstitution'
+
+            # @param offense [Hash]
+            # @return [String]
+            def build_message(offense)
+              MessagesBuilder.call(offense)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/text_substitution/validator.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/validator.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module TextSubstitution
+          # Validates that documentation does not contain forbidden strings.
+          # Reports every matching substitution rule on every line independently.
+          class Validator < Base
+            in_process visibility: :public
+
+            # @param object [YARD::CodeObjects::Base]
+            # @param collector [Executor::ResultCollector]
+            # @return [void]
+            def in_process_query(object, collector)
+              docstring_text = object.docstring.to_s
+              return if docstring_text.empty?
+
+              substitutions = config_or_default('Substitutions')
+              return if substitutions.nil? || substitutions.empty?
+
+              violations = find_violations(docstring_text, substitutions)
+              return if violations.empty?
+
+              violations.each do |violation|
+                collector.puts "#{object.file}:#{object.line}: #{object.title}"
+                collector.puts "#{violation[:forbidden]}|#{violation[:replacement]}|" \
+                               "#{violation[:line_offset]}|#{violation[:line_text]}"
+              end
+            end
+
+            private
+
+            def find_violations(docstring_text, substitutions)
+              violations = []
+              in_code_block = false
+
+              docstring_text.lines.each_with_index do |line, line_offset|
+                if line.strip.start_with?('```')
+                  in_code_block = !in_code_block
+                  next
+                end
+                next if in_code_block
+
+                substitutions.each do |forbidden, replacement|
+                  next unless line.include?(forbidden)
+
+                  violations << {
+                    forbidden: forbidden,
+                    replacement: replacement,
+                    line_offset: line_offset,
+                    line_text: line.strip
+                  }
+                end
+              end
+
+              violations
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/text_substitution/validator.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/validator.rb
@@ -32,6 +32,10 @@ module Yard
 
             private
 
+            # Scans each line of a docstring for forbidden strings, skipping fenced code blocks.
+            # @param docstring_text [String] full docstring text to scan
+            # @param substitutions [Hash{String => String}] map of forbidden string to replacement
+            # @return [Array<Hash>] list of violations with forbidden, replacement, line_offset, line_text
             def find_violations(docstring_text, substitutions)
               violations = []
               in_code_block = false

--- a/lib/yard/lint/validators/documentation/text_substitution/validator.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/validator.rb
@@ -25,8 +25,9 @@ module Yard
 
               violations.each do |violation|
                 collector.puts "#{object.file}:#{object.line}: #{object.title}"
-                collector.puts "#{violation[:forbidden]}|#{violation[:replacement]}|" \
-                               "#{violation[:line_offset]}|#{violation[:line_text]}"
+                collector.puts violation[:forbidden]
+                collector.puts violation[:replacement]
+                collector.puts "#{violation[:line_offset]}|#{violation[:line_text]}"
               end
             end
 
@@ -48,6 +49,8 @@ module Yard
                 next if in_code_block
 
                 substitutions.each do |forbidden, replacement|
+                  next if forbidden.nil? || forbidden.empty?
+                  next if replacement.nil? || replacement.empty?
                   next unless line.include?(forbidden)
 
                   violations << {

--- a/test/fixtures/text_substitution_examples.rb
+++ b/test/fixtures/text_substitution_examples.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Fixture for the TextSubstitution validator integration tests.
+
+# A class whose documentation contains em-dash — characters.
+class TextSubstitutionExamples
+  # Connects the start — and end of the range.
+  # @param start [Integer] start value
+  # @param finish [Integer] end value
+  # @return [Range]
+  def em_dash_method(start, finish)
+    start..finish
+  end
+
+  # Uses an en-dash – for indicating ranges in prose.
+  # @return [String]
+  def en_dash_method
+    'result'
+  end
+
+  # Both em-dash — and en-dash – appear on the same line here.
+  # @return [String]
+  def both_dashes_method
+    'result'
+  end
+
+  # Em-dash inside a fenced code block must not trigger.
+  #
+  # ```ruby
+  # # This em-dash — and en-dash – are inside a code fence
+  # ```
+  #
+  # @return [String]
+  def with_code_block
+    'safe'
+  end
+
+  # Uses a plain hyphen - which is perfectly acceptable.
+  # @return [String]
+  def plain_hyphen_method
+    'fine'
+  end
+end

--- a/test/integrations/text_substitution_test.rb
+++ b/test/integrations/text_substitution_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+describe 'TextSubstitution' do
+  attr_reader :fixture_path, :config, :test_dir
+
+  before do
+    @fixture_path = File.expand_path('../fixtures/text_substitution_examples.rb', __dir__)
+    @config = test_config do |c|
+      c.set_validator_config('Documentation/TextSubstitution', 'Enabled', true)
+    end
+    @test_dir = Dir.mktmpdir
+  end
+
+  after do
+    FileUtils.rm_rf(@test_dir) if @test_dir && File.exist?(@test_dir)
+  end
+
+  def create_test_file(filename, content)
+    path = File.join(@test_dir, filename)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  def text_sub_offenses(result)
+    result.offenses.select { |o| o[:name].to_s == 'TextSubstitution' }
+  end
+
+  it 'detects em-dash in documentation' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+    offenses = text_sub_offenses(result).select { |o| o[:forbidden] == "—" }
+    refute_empty(offenses)
+    assert(offenses.all? { |o| o[:message].include?("'—'") })
+    assert(offenses.all? { |o| o[:message].include?("'-'") })
+  end
+
+  it 'detects en-dash in documentation' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+    offenses = text_sub_offenses(result).select { |o| o[:forbidden] == "–" }
+    refute_empty(offenses)
+  end
+
+  it 'does not flag plain hyphens' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+    offenses = text_sub_offenses(result)
+    plain_offenses = offenses.select { |o| o[:object_name]&.include?('plain_hyphen') }
+    assert_empty(plain_offenses)
+  end
+
+  it 'does not flag content inside fenced code blocks' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+    offenses = text_sub_offenses(result)
+    code_block_offenses = offenses.select { |o| o[:object_name]&.include?('with_code_block') }
+    assert_empty(code_block_offenses)
+  end
+
+  it 'is disabled by default' do
+    default_config = test_config
+    result = Yard::Lint.run(path: fixture_path, config: default_config, progress: false)
+    assert_empty(text_sub_offenses(result))
+  end
+
+  it 'reports two separate violations when both em-dash and en-dash appear on the same line' do
+    file = create_test_file('multi_violation.rb', <<~RUBY)
+      # Both em-dash — and en-dash – on one line.
+      def multi_violation_method
+        :ok
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: config, progress: false)
+    offenses = text_sub_offenses(result)
+
+    assert_equal(2, offenses.size)
+    assert_includes(offenses.map { |o| o[:forbidden] }, "—")
+    assert_includes(offenses.map { |o| o[:forbidden] }, "–")
+  end
+
+  it 'respects user-configured substitutions' do
+    custom_config = test_config do |c|
+      c.set_validator_config('Documentation/TextSubstitution', 'Enabled', true)
+      c.set_validator_config('Documentation/TextSubstitution', 'Substitutions',
+                             { '...' => 'ellipsis' })
+    end
+
+    file = create_test_file('custom_sub.rb', <<~RUBY)
+      # Loading... please wait.
+      def loading_method
+        :loading
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: custom_config, progress: false)
+    offenses = text_sub_offenses(result)
+    refute_empty(offenses)
+    assert_includes(offenses.first[:message], "Replace '...' with 'ellipsis'")
+  end
+
+  it 'includes the offending line text in the message' do
+    file = create_test_file('msg_format.rb', <<~RUBY)
+      # Connects the start — and end.
+      def msg_format_method
+        :ok
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: config, progress: false)
+    offenses = text_sub_offenses(result)
+    refute_empty(offenses)
+    assert_includes(offenses.first[:message], 'Found:')
+  end
+
+  it 'offense name is TextSubstitution' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+    offenses = text_sub_offenses(result)
+    refute_empty(offenses)
+    assert(offenses.all? { |o| o[:name].to_s == 'TextSubstitution' })
+  end
+
+  it 'offense severity is warning by default' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+    offenses = text_sub_offenses(result)
+    refute_empty(offenses)
+    assert(offenses.all? { |o| o[:severity] == 'warning' })
+  end
+
+  it 'offense validator is Documentation/TextSubstitution' do
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+    offenses = text_sub_offenses(result)
+    refute_empty(offenses)
+    assert(offenses.all? { |o| o[:validator] == 'Documentation/TextSubstitution' })
+  end
+end

--- a/test/integrations/text_substitution_test.rb
+++ b/test/integrations/text_substitution_test.rb
@@ -113,6 +113,28 @@ describe 'TextSubstitution' do
     assert_includes(offenses.first[:message], 'Found:')
   end
 
+  it 'correctly parses forbidden strings that contain pipe characters' do
+    custom_config = test_config do |c|
+      c.set_validator_config('Documentation/TextSubstitution', 'Enabled', true)
+      c.set_validator_config('Documentation/TextSubstitution', 'Substitutions',
+                             { 'a|b' => 'c' })
+    end
+
+    file = create_test_file('pipe_in_forbidden.rb', <<~RUBY)
+      # This text contains a|b which should be flagged.
+      def pipe_method
+        :ok
+      end
+    RUBY
+
+    result = Yard::Lint.run(path: file, config: custom_config, progress: false)
+    offenses = text_sub_offenses(result)
+    refute_empty(offenses)
+    assert_equal('a|b', offenses.first[:forbidden])
+    assert_equal('c', offenses.first[:replacement])
+    assert_includes(offenses.first[:message], "Replace 'a|b' with 'c'")
+  end
+
   it 'offense name is TextSubstitution' do
     result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
     offenses = text_sub_offenses(result)


### PR DESCRIPTION
## Summary

- Adds a new opt-in `Documentation/TextSubstitution` validator that detects forbidden characters/strings in YARD documentation and suggests user-defined replacements
- Ships with em-dash (—, U+2014) and en-dash (–, U+2013) → hyphen as built-in defaults to catch AI-generated punctuation that projects prefer as plain ASCII hyphens
- Reports **every** matching substitution rule per line independently (unlike `Tags/InformalNotation` which stops at the first match per line), so a line with both an em-dash and an en-dash produces two violations
- Fenced code blocks (` ``` `) are skipped
- Users configure arbitrary `String → String` rules via the `Substitutions` key:

```yaml
Documentation/TextSubstitution:
  Enabled: true
  Substitutions:
    "—": "-"    # em-dash (U+2014)
    "–": "-"    # en-dash (U+2013)
    "…": "..."  # any string → any string
```

## Test plan

- [ ] `bundle exec rake test TEST=test/integrations/text_substitution_test.rb` — 12 tests: em-dash detection, en-dash detection, plain hyphen not flagged, fenced code block skipped, disabled by default, two violations on one line, custom substitution rules, message format, offense name/severity/validator fields
- [ ] `bundle exec rake test` — full suite passes (2096 runs, 0 failures)