### PR TITLE
Fix boolean validator options set to false being silently ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # YARD-Lint Changelog
 
+## Unreleased
+- **[Fix]** Boolean validator options explicitly set to `false` in `.yard-lint.yml` are no longer silently ignored. The shared config fallback (`Validators::Base#config_or_default` and `Config#get_validator_config_with_default`) used `value || default`, so a user-configured `false` fell through to the truthy default — e.g. `Tags/InformalNotation: RequireStartOfLine: false` had no effect and mid-line informal notation was never reported. The fallback now only applies when the key is genuinely unset (`nil`).
+
 ## 1.6.1 (2026-06-11)
 - **[Fix]** `Documentation/OrphanedDocComment` no longer reports false positives for documented DSL-style method calls (e.g. `ransacker :foo do … end`, `validates :name`, `scope :active, -> { … }`). YARD's DSL handler turns such a call into a documentable method object when the preceding comment carries an implicit-docstring tag (`@return`, `@overload`, `@method`, `@attribute`, `@scope`, `@visibility`), so the comment is attached rather than dropped. The validator now recognises this case: a tagged comment before a DSL call is only flagged when the call is one YARD's handler ignores (`include`, `extend`, `private :sym`, etc.) or the comment lacks an implicit-docstring tag (in which case YARD really does drop it). Also fixes a pre-existing false positive for the bare `attr :name` attribute form.
 

--- a/lib/yard/lint/config.rb
+++ b/lib/yard/lint/config.rb
@@ -243,10 +243,13 @@ module Yard
       # @param key [String] configuration key
       # @return [Object, nil] configuration value or default
       def get_validator_config_with_default(validator_name, key)
-        validator_config(validator_name, key) || begin
-          validator_cfg = ConfigLoader.validator_config(validator_name)
-          validator_cfg&.defaults&.dig(key)
-        end
+        value = validator_config(validator_name, key)
+        # A nil? check (not ||) so that explicitly configured false values
+        # are honored instead of falling back to a truthy default
+        return value unless value.nil?
+
+        validator_cfg = ConfigLoader.validator_config(validator_name)
+        validator_cfg&.defaults&.dig(key)
       end
 
       # Get AllValidators section

--- a/lib/yard/lint/validators/base.rb
+++ b/lib/yard/lint/validators/base.rb
@@ -236,7 +236,10 @@ module Yard
 
           return defaults[key] unless validator_name
 
-          config.validator_config(validator_name, key) || defaults[key]
+          value = config.validator_config(validator_name, key)
+          # A nil? check (not ||) so that explicitly configured false values
+          # are honored instead of falling back to a truthy default
+          value.nil? ? defaults[key] : value
         end
       end
     end

--- a/test/fixtures/informal_notation_midline.rb
+++ b/test/fixtures/informal_notation_midline.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Fixture for boolean config override tests. The informal notation appears
+# only mid-line, so it is reported solely when RequireStartOfLine is false.
+class MidlineInformalNotation
+  # Runs the calculation. Note: results are memoized between calls.
+  # @return [void]
+  def call; end
+end

--- a/test/integrations/boolean_config_override_test.rb
+++ b/test/integrations/boolean_config_override_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Proves that a user-configured `false` overrides a truthy validator default.
+# `Tags/InformalNotation` has `RequireStartOfLine: true` by default; the fixture
+# contains an informal `Note:` only mid-line, which is reported exclusively when
+# the user successfully sets `RequireStartOfLine: false`.
+describe 'Boolean config override' do
+  attr_reader :fixture_path
+
+  before do
+    @fixture_path = File.expand_path('../fixtures/informal_notation_midline.rb', __dir__)
+  end
+
+  it 'honors a user-configured false for a boolean option with a truthy default' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InformalNotation', 'Enabled', true)
+      c.set_validator_config('Tags/InformalNotation', 'RequireStartOfLine', false)
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    informal_offenses = result.offenses.select { |o| o[:name] == 'InformalNotation' }
+
+    refute_empty(
+      informal_offenses,
+      'RequireStartOfLine: false was ignored - mid-line informal notation not reported'
+    )
+    assert_includes(informal_offenses.first[:message], "'Note:'")
+  end
+
+  it 'keeps the truthy default when the user does not override it' do
+    config = test_config do |c|
+      c.set_validator_config('Tags/InformalNotation', 'Enabled', true)
+    end
+
+    result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+
+    informal_offenses = result.offenses.select { |o| o[:name] == 'InformalNotation' }
+
+    assert_empty(
+      informal_offenses,
+      'mid-line informal notation must not be reported with default RequireStartOfLine: true'
+    )
+  end
+end

--- a/test/yard/lint/validators/base_test.rb
+++ b/test/yard/lint/validators/base_test.rb
@@ -126,6 +126,34 @@ describe 'YardLintValidatorsBaseConfigOrDefault' do
     end
   end
 
+  it 'config or default when config value is false returns false instead of the default' do
+    config.stubs(:validator_config)
+      .with('Tags/TestValidator', 'SomeKey')
+      .returns(false)
+
+    unless defined?(Yard::Lint::Validators::Tags::TestValidator)
+      Yard::Lint::Validators::Tags.const_set(:TestValidator, Module.new)
+    end
+
+    config_class = Class.new do
+      def self.defaults
+        { 'SomeKey' => true }
+      end
+    end
+
+    Yard::Lint::Validators::Tags::TestValidator.const_set(:Config, config_class)
+
+    result = validator.send(:config_or_default, 'SomeKey')
+    assert_equal(false, result)
+  ensure
+    if defined?(Yard::Lint::Validators::Tags::TestValidator::Config)
+      Yard::Lint::Validators::Tags::TestValidator.send(:remove_const, :Config)
+    end
+    if defined?(Yard::Lint::Validators::Tags::TestValidator)
+      Yard::Lint::Validators::Tags.send(:remove_const, :TestValidator)
+    end
+  end
+
   it 'config or default when validator name cannot be extracted returns nil' do
     invalid_validator_class = Class.new(Yard::Lint::Validators::Base) do
       def self.name


### PR DESCRIPTION
## Summary

Fixes **BUG-001** from the linter audit: boolean validator options explicitly set to `false` in `.yard-lint.yml` were silently ignored.

The shared config fallback used `value || default`, so a user-configured `false` fell through to the truthy default. Concretely, `Tags/InformalNotation: RequireStartOfLine: false` had no effect — mid-line informal notation (`Runs the calculation. Note: ...`) was never reported. This affected every boolean option with a truthy default read through the shared helpers.

## Changes

- `Validators::Base#config_or_default`: replace the `||` fallback with a `nil?` check so the default only applies when the key is genuinely unset
- `Config#get_validator_config_with_default`: same root cause, same fix (public API, currently uncalled internally)
- Integration test (`test/integrations/boolean_config_override_test.rb`) that **fails on the previous code**: with `RequireStartOfLine: false`, mid-line informal notation must be reported; a companion case asserts the truthy default still holds when not overridden
- Unit test for `config_or_default` returning a configured `false` instead of the default
- CHANGELOG entry under Unreleased

## Verification

- New integration test fails before the fix, passes after
- Full suite: 2107 runs, 4689 assertions, 0 failures
- `rubocop` (CI scope) and `bin/yard-lint lib/` both clean