### PR TITLE
Fix offenses on top-level methods and constants being silently dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # YARD-Lint Changelog
 
 ## Unreleased
+- **[Fix]** Offenses on top-level (root namespace) methods and on constants are no longer silently discarded. The location regex shared by the `Documentation/UndocumentedMethodArguments` and `Tags/InvalidTypes` parsers required a `#` or `.` separator in the object title, so titles like `#my_method` (top-level method) or `MAX_RETRIES` (constant) never matched and their offenses were dropped after the validator had already detected them. `Tags/Order` was affected too via the shared parser: a dropped location line shifted the parallel expected-order list, so surviving offenses could be reported with another method's expected tag order. The parsers now accept any object title and split namespace/method name on the last separator when one is present.
 - **[Fix]** Boolean validator options explicitly set to `false` in `.yard-lint.yml` are no longer silently ignored. The shared config fallback (`Validators::Base#config_or_default` and `Config#get_validator_config_with_default`) used `value || default`, so a user-configured `false` fell through to the truthy default — e.g. `Tags/InformalNotation: RequireStartOfLine: false` had no effect and mid-line informal notation was never reported. The fallback now only applies when the key is genuinely unset (`nil`).
 
 ## 1.6.1 (2026-06-11)

--- a/lib/yard/lint/validators/documentation/undocumented_method_arguments/parser.rb
+++ b/lib/yard/lint/validators/documentation/undocumented_method_arguments/parser.rb
@@ -9,9 +9,13 @@ module Yard
           # @example Output format (skip-lint)
           #   /path/to/file.rb:10: Platform::Analysis::Authors#initialize
           class Parser < Parsers::Base
-            # Regex to extract file, line, and method name from yard list output
+            # Regex to extract file, line, and object title from yard list output
             # Format: /path/to/file.rb:10: ClassName#method_name
-            LOCATION_REGEX = /^(.+):(\d+):\s+(.+)[#.](.+)$/
+            LOCATION_REGEX = /^(.+):(\d+):\s+(.+)$/
+            # Splits an object title into namespace and method name on the last
+            # # or . separator. Top-level methods (#foo) have an empty namespace;
+            # titles without a separator (e.g. Foo::Bar, CONST) are kept whole.
+            TITLE_REGEX = /\A(.*)[#.]([^#.]+)\z/
 
             # @param yard_list [String] raw yard list results string
             # @return [Array<Hash>] Array with undocumented method arguments details
@@ -26,8 +30,7 @@ module Yard
                   # Extract: file path, line number, class name, method name
                   file_path = match_data[1]
                   line_number = match_data[2].to_i
-                  class_name = match_data[3]
-                  method_name = match_data[4]
+                  class_name, method_name = split_title(match_data[3])
 
                   {
                     location: file_path,
@@ -36,6 +39,17 @@ module Yard
                     class_name: class_name
                   }
                 end
+            end
+
+            private
+
+            # Splits a YARD object title into namespace and method name parts
+            # @param title [String] object title (e.g. "Foo#bar", "#bar", "CONST")
+            # @return [Array(String, String)] namespace and method name; for titles
+            #   without a separator both parts are the full title
+            def split_title(title)
+              match = title.match(TITLE_REGEX)
+              match ? [match[1], match[2]] : [title, title]
             end
           end
         end

--- a/lib/yard/lint/validators/tags/invalid_types/parser.rb
+++ b/lib/yard/lint/validators/tags/invalid_types/parser.rb
@@ -10,8 +10,12 @@ module Yard
           #   /path/to/file.rb:10: ClassName#method_name
           #   @tagname param_name:BadType1,BadType2|@tagname2:BadType3
           class Parser < Parsers::Base
-            # @return [Regexp] matches "file:line: ClassName#method"
-            LOCATION_REGEX = /^(.+):(\d+):\s+(.+)[#.](.+)$/
+            # @return [Regexp] matches "file:line: ObjectTitle"
+            LOCATION_REGEX = /^(.+):(\d+):\s+(.+)$/
+            # @return [Regexp] splits a title into namespace and method name on
+            #   the last # or . separator; titles without one (e.g. CONST,
+            #   Foo::Bar) are kept whole
+            TITLE_REGEX = /\A(.*)[#.]([^#.]+)\z/
             # @return [Regexp] matches the tag violations line (starts with @)
             TAG_VIOLATIONS_REGEX = /^@/
 
@@ -23,18 +27,22 @@ module Yard
               i = 0
 
               while i < lines.size
-                match = lines[i].match(LOCATION_REGEX)
+                # Violation lines (starting with @) must never be consumed as
+                # location lines, even if they happen to match the loose regex
+                match = lines[i].match?(TAG_VIOLATIONS_REGEX) ? nil : lines[i].match(LOCATION_REGEX)
 
                 unless match
                   i += 1
                   next
                 end
 
+                class_name, method_name = split_title(match[3])
+
                 offense = {
                   location: match[1],
                   line: match[2].to_i,
-                  class_name: match[3],
-                  method_name: match[4],
+                  class_name: class_name,
+                  method_name: method_name,
                   tag_violations: []
                 }
 
@@ -53,6 +61,15 @@ module Yard
             end
 
             private
+
+            # Splits a YARD object title into namespace and method name parts
+            # @param title [String] object title (e.g. "Foo#bar", "#bar", "CONST")
+            # @return [Array(String, String)] namespace and method name; for titles
+            #   without a separator both parts are the full title
+            def split_title(title)
+              match = title.match(TITLE_REGEX)
+              match ? [match[1], match[2]] : [title, title]
+            end
 
             # Parse "tagname param:Type1,Type2|tagname2:Type3" into structured data
             # @param line [String] the violations line

--- a/test/fixtures/top_level_offenses.rb
+++ b/test/fixtures/top_level_offenses.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Fixture for parser location-regex tests. All offenses here live on
+# top-level (root namespace) methods or constants, whose YARD titles
+# (#method_name, CONST_NAME) carry no Class#method separator.
+
+# Adds two numbers together
+# @param first [Integer] first number
+def top_level_partially_documented(first, second)
+  first + second
+end
+
+# Returns a label
+# @return [strng] mistyped lowercase type
+def top_level_invalid_type
+  'label'
+end
+
+# Maximum number of retries
+# @return [strng] mistyped lowercase type
+TOP_LEVEL_BAD_CONST = 5
+
+# Builds a label
+# @return [String] the label
+# @param value [String] input value
+def top_level_wrong_tag_order(value)
+  value
+end

--- a/test/integrations/top_level_offenses_test.rb
+++ b/test/integrations/top_level_offenses_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Proves that offenses on top-level (root namespace) methods and on constants
+# are reported. Their YARD titles (#method_name, CONST_NAME) have no
+# Class#method separator, which the location regex used by the
+# UndocumentedMethodArguments and InvalidTypes parsers used to require,
+# silently discarding such offenses (and, via the shared parser, Tags/Order
+# locations too).
+describe 'Top-level and constant offenses' do
+  attr_reader :fixture_path, :result
+
+  before do
+    @fixture_path = File.expand_path('../fixtures/top_level_offenses.rb', __dir__)
+    config = test_config
+    @result = Yard::Lint.run(path: fixture_path, config: config, progress: false)
+  end
+
+  it 'reports undocumented arguments of a top-level method' do
+    offenses = result.offenses.select do |o|
+      o[:name] == 'UndocumentedMethodArgument' &&
+        o[:message].include?('top_level_partially_documented')
+    end
+
+    refute_empty(offenses, 'offense on a top-level method was dropped by the parser')
+
+    assert_operator(offenses.first[:line], :>, 0)
+  end
+
+  it 'reports an invalid tag type on a top-level method' do
+    offenses = result.offenses.select do |o|
+      o[:name] == 'InvalidTagType' &&
+        o[:message].include?('top_level_invalid_type')
+    end
+
+    refute_empty(offenses, 'offense on a top-level method was dropped by the parser')
+
+    assert_includes(offenses.first[:message], '`strng`')
+  end
+
+  it 'reports an invalid tag type on a constant' do
+    offenses = result.offenses.select do |o|
+      o[:name] == 'InvalidTagType' &&
+        o[:message].include?('TOP_LEVEL_BAD_CONST')
+    end
+
+    refute_empty(offenses, 'offense on a constant was dropped by the parser')
+
+    assert_includes(offenses.first[:message], '`strng`')
+  end
+
+  it 'reports wrong tag order on a top-level method with its own expected order' do
+    offenses = result.offenses.select do |o|
+      o[:name] == 'InvalidTagOrder' &&
+        o[:message].include?('top_level_wrong_tag_order')
+    end
+
+    refute_empty(offenses, 'offense on a top-level method was dropped by the parser')
+
+    # The expected order must belong to this method (param before return),
+    # not to another offense shifted by a dropped location line
+    assert_includes(offenses.first[:message], '`param`, `return`')
+  end
+end


### PR DESCRIPTION
## Summary

Fixes **BUG-003** from the linter audit: offenses detected on top-level (root namespace) methods and on constants were silently discarded at the parsing stage.

`LOCATION_REGEX = /^(.+):(\d+):\s+(.+)[#.](.+)$/` (shared by the `Documentation/UndocumentedMethodArguments` and `Tags/InvalidTypes` parsers) required a `#` or `.` separator in the object title. Top-level method titles (`#my_method`) and constant titles (`MAX_RETRIES`) never matched, so the validator detected the offense but the parser dropped it. `Tags/Order` was affected through the shared parser: a dropped location line shifted its parallel expected-order array, so surviving offenses could be reported with **another method's** expected tag order.

Reproduction before the fix — the InvalidTypes validator emits 3 offenses, the parser keeps 1:
```
--- raw validator output:
/tmp/bug003/invalid_types.rb:5: #top_bad_type
@return:strng
/tmp/bug003/invalid_types.rb:11: MAX_RETRIES
@return:strng
/tmp/bug003/invalid_types.rb:17: Holder#inner_bad_type
@return:strng
--- parsed:
[{... Holder#inner_bad_type only ...}]
```

## Changes

- Both parsers now accept any object title (`/^(.+):(\d+):\s+(.+)$/`) and split namespace/method name on the **last** `#`/`.` separator when one is present (`#foo` → empty namespace + `foo`; `CONST` → kept whole)
- InvalidTypes' two-line stream explicitly guards violation lines (`@...`) so the looser location regex can never consume them
- Integration tests (`test/integrations/top_level_offenses_test.rb`) that **fail on the previous code** — all four failed before the fix:
  - `UndocumentedMethodArgument` on a top-level method
  - `InvalidTagType` on a top-level method
  - `InvalidTagType` on a constant
  - `InvalidTagOrder` on a top-level method, asserting it carries **its own** expected-order message
- CHANGELOG entry under Unreleased

## Audit correction

`Documentation/MissingReturn` was originally listed in BUG-003 but is **not** affected — its parser uses a different regex (`(.+?)\|`) that handles top-level titles correctly; the audit repro was fooled by the validator being disabled by default. Verified during this fix.

## Verification

- New integration tests: 4 failures before, all pass after
- Full suite: 2111 runs, 4705 assertions, 0 failures
- `rubocop` (CI scope) and `bin/yard-lint lib/` both clean