### PR TITLE
Fix SimpleCov add_filter deprecation; treat Ruby 4.0 as stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
 
       - name: Run YARD Lint (dogfooding)
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
 
       - name: Run rubocop

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: false
 
       - name: Bundle install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    docile (1.4.1)
     drb (2.2.3)
     json (2.20.0)
     language_server-protocol (3.17.0.6)
@@ -50,12 +49,7 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.0)
     standard (1.55.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,8 +29,8 @@ if RUBY_VERSION.start_with?('4.0')
   require 'simplecov'
 
   SimpleCov.start do
-    add_filter '/test/'
-    add_filter '/vendor/'
+    skip '/test/'
+    skip '/vendor/'
 
     minimum_coverage 95
   end


### PR DESCRIPTION
## Problem

SimpleCov 1.0.0 (released 2026-07-12) renamed `add_filter` to `skip` and emits a deprecation warning for the old name. The test suite promotes warnings to errors, so CI breaks as soon as `simplecov` resolves to 1.0.0.

## Changes

- **`test/test_helper.rb`**: `add_filter` -> `skip` (the new SimpleCov 1.0.0 API).
- **`Gemfile.lock`**: `bundle lock --update simplecov` bumps `simplecov` 0.22.0 -> **1.0.0**. Its old runtime deps (`docile`, `simplecov-html`, `simplecov_json_formatter`) are no longer required and drop out of the lock. `simplecov` stays unpinned in the `Gemfile`.
- **`.github/workflows/{ci,push}.yml`**: loosen the pinned `ruby-version: '4.0.5'` to `'4.0'` so the aux jobs (`yard-lint`, `rubocop`, `push`) track 4.0.LATEST instead of a frozen patch release.

## Ruby 4.0

Ruby 4.0 is treated as a normal, stable, **required** matrix entry — no preview handling, no `continue-on-error`, no lockfile juggling.

Test matrix: `['3.3', '3.4', '4.0']` (macOS runs 3.4 only, as before).

Coverage is gated on Ruby 4.0 in `test/test_helper.rb`:

```ruby
if RUBY_VERSION.start_with?('4.0')
  require 'simplecov'
  ...
end
```

`setup-ruby` resolves `'4.0'` to the latest 4.0.x (e.g. 4.0.5), so `RUBY_VERSION` is `4.0.x` and the gate still matches — coverage continues to run on exactly one job.

There are no Ruby 4.1 references anywhere in `.github/workflows/` (4.1 does not exist in `setup-ruby` yet).