### PR TITLE
Add Documentation/DuplicateNamespaceComment validator

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -99,6 +99,11 @@ Documentation/TextSubstitution:
     "—": "-"    # em-dash (U+2014)
     "–": "-"    # en-dash (U+2013)
 
+Documentation/DuplicateNamespaceComment:
+  Description: 'Detects namespaces (modules and classes) documented in more than one file.'
+  Enabled: true
+  Severity: error
+
 # Tags validators
 Tags/Order:
   Description: 'Enforces consistent ordering of YARD tags.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.0 (2026-07-21)
+- **[Feature]** Added `Documentation/DuplicateNamespaceComment` (enabled by default, severity `warning`) - detects namespaces (modules and classes) that carry a YARD documentation comment in more than one file. When a namespace is reopened across files and documented in several of them, YARD merges the reopenings into a single object and keeps only one docstring, silently discarding the rest (the last documented reopening wins, with no warning), so competing descriptions are lost. This is a common accident for shared namespaces (e.g. `Users` or `Users::Operations`) spread across many files; it does not affect a leaf object such as `Users::Operations::Create` that lives in a single file. Because YARD does not record which reopening carried a comment, the validator re-reads each definition site to detect the documented ones (ignoring blank-line-detached comments and directive/magic comments), and reports one offense per namespace documented in two or more files, listing every documented location and noting when the docstrings differ (meaning content is actually lost). Configurable via the standard `Enabled` and `Severity` keys.
+
 ## 1.9.0 (2026-07-01)
 - **[Breaking]** Dropped support for Ruby 3.2. The minimum required Ruby version is now 3.3.0. This change was necessary because the `parallel` gem no longer supports Ruby 3.2.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yard-lint (1.9.0)
+    yard-lint (1.10.0)
       yard (~> 0.9)
       zeitwerk (~> 2.6)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ YARD-Lint validates your YARD documentation for:
 - **Performance** - In-process YARD execution with shared registry (~10x faster than shell-based execution)
 - **Incremental Adoption** - `--auto-gen-config` generates a baseline todo file to adopt on legacy codebases without fixing everything first
 
-**See the complete list:** [All Features](https://github.com/mensfeld/yard-lint/wiki/Features) | [36 Validators](https://github.com/mensfeld/yard-lint/wiki/Validators)
+**See the complete list:** [All Features](https://github.com/mensfeld/yard-lint/wiki/Features) | [37 Validators](https://github.com/mensfeld/yard-lint/wiki/Validators)
 
 ## Installation
 
@@ -569,7 +569,7 @@ The text formatter also shows the validator path (e.g., `[Documentation/Orphaned
 - **[Wiki Home](https://github.com/mensfeld/yard-lint/wiki)** - Full documentation
 - **[Installation](https://github.com/mensfeld/yard-lint/wiki/Installation)** - Installation guide
 - **[Configuration](https://github.com/mensfeld/yard-lint/wiki/Configuration)** - Complete configuration reference
-- **[Validators](https://github.com/mensfeld/yard-lint/wiki/Validators)** - All 35 validators documented
+- **[Validators](https://github.com/mensfeld/yard-lint/wiki/Validators)** - All 37 validators documented
 - **[Features](https://github.com/mensfeld/yard-lint/wiki/Features)** - All features explained
 
 ### Workflows

--- a/lib/yard/lint.rb
+++ b/lib/yard/lint.rb
@@ -10,6 +10,7 @@ require 'did_you_mean'
 require 'yard'
 require 'set'
 
+# YARD Lint - comprehensive linter for YARD documentation
 module Yard
   # YARD Lint module providing linting functionality for YARD documentation
   module Lint

--- a/lib/yard/lint/config.rb
+++ b/lib/yard/lint/config.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# YARD Lint - comprehensive linter for YARD documentation
 module Yard
   module Lint
     # Configuration object for YARD Lint

--- a/lib/yard/lint/config_validator.rb
+++ b/lib/yard/lint/config_validator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# YARD Lint - comprehensive linter for YARD documentation
 module Yard
-  # YARD Lint module providing linting functionality for YARD documentation
   module Lint
     # Validates configuration structure and values to catch typos and invalid settings
     class ConfigValidator

--- a/lib/yard/lint/templates/default_config.yml
+++ b/lib/yard/lint/templates/default_config.yml
@@ -137,6 +137,11 @@ Documentation/TextSubstitution:
     "—": "-"    # em-dash (U+2014)
     "–": "-"    # en-dash (U+2013)
 
+Documentation/DuplicateNamespaceComment:
+  Description: 'Detects namespaces (modules and classes) documented in more than one file.'
+  Enabled: true
+  Severity: warning
+
 # Tags validators
 Tags/Order:
   Description: 'Enforces consistent ordering of YARD tags.'

--- a/lib/yard/lint/templates/strict_config.yml
+++ b/lib/yard/lint/templates/strict_config.yml
@@ -135,6 +135,11 @@ Documentation/TextSubstitution:
     "—": "-"    # em-dash (U+2014)
     "–": "-"    # en-dash (U+2013)
 
+Documentation/DuplicateNamespaceComment:
+  Description: 'Detects namespaces (modules and classes) documented in more than one file.'
+  Enabled: true
+  Severity: error
+
 # Tags validators
 Tags/Order:
   Description: 'Enforces consistent ordering of YARD tags.'

--- a/lib/yard/lint/validators/documentation/duplicate_namespace_comment.rb
+++ b/lib/yard/lint/validators/documentation/duplicate_namespace_comment.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        # DuplicateNamespaceComment validator
+        #
+        # Detects namespaces (modules and classes) that carry a YARD documentation
+        # comment in more than one file. When a namespace is reopened across several
+        # files, YARD merges every reopening into a single object and keeps only one
+        # docstring - the last documented reopening wins and all the other comments are
+        # silently discarded, with no warning. This is a common accident for shared
+        # namespaces (e.g. `Users` or `Users::Operations`) that are spread across many
+        # files. It is not a concern for a leaf object such as `Users::Operations::Create`
+        # which is normally defined in a single file and can only be documented once.
+        #
+        # The validator reports one offense per namespace that is documented in two or
+        # more files, listing every documented location so the duplicates can be
+        # consolidated into a single canonical spot.
+        #
+        # @example Bad - the same namespace documented in two files
+        #   # a.rb
+        #   # Handles user operations
+        #   module Users; end
+        #
+        #   # b.rb
+        #   # User-related helpers   # &lt;- silently discarded by YARD
+        #   module Users; end
+        #
+        # @example Good - document the namespace in exactly one place
+        #   # a.rb
+        #   # Handles user operations
+        #   module Users; end
+        #
+        #   # b.rb
+        #   module Users; end        # &lt;- reopened without a comment
+        #
+        # ## Configuration
+        #
+        # To disable this validator:
+        #
+        #     Documentation/DuplicateNamespaceComment:
+        #       Enabled: false
+        module DuplicateNamespaceComment
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/duplicate_namespace_comment/config.rb
+++ b/lib/yard/lint/validators/documentation/duplicate_namespace_comment/config.rb
@@ -3,15 +3,14 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
-      module Warnings
-        module DuplicatedParameterName
-          # Configuration for DuplicatedParameterName validator
+      module Documentation
+        module DuplicateNamespaceComment
+          # Configuration for DuplicateNamespaceComment validator
           class Config < ::Yard::Lint::Validators::Config
-            self.id = :duplicated_parameter_name
+            self.id = :duplicate_namespace_comment
             self.defaults = {
               'Enabled' => true,
-              'Severity' => 'error'
+              'Severity' => 'warning'
             }.freeze
           end
         end

--- a/lib/yard/lint/validators/documentation/duplicate_namespace_comment/messages_builder.rb
+++ b/lib/yard/lint/validators/documentation/duplicate_namespace_comment/messages_builder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module DuplicateNamespaceComment
+          # Builds messages for duplicate namespace comment offenses
+          class MessagesBuilder
+            # Maximum number of documented locations listed inline in the message
+            MAX_LISTED_SITES = 5
+
+            class << self
+              # Build message for a namespace documented in multiple files
+              # @param offense [Hash] offense data with :namespace, :sites and :conflict keys
+              # @return [String] formatted message
+              def call(offense)
+                sites = Array(offense[:sites])
+                listed = sites.first(MAX_LISTED_SITES).map { |site| relativize(site) }
+                remainder = sites.size - listed.size
+                located = listed.join(', ')
+                located += " (+#{remainder} more)" if remainder.positive?
+
+                differ = offense[:conflict] == 'differ' ? ' The docstrings differ, so content is lost.' : ''
+
+                "Namespace `#{offense[:namespace]}` is documented in #{sites.size} files; " \
+                  "YARD keeps only one docstring and discards the rest.#{differ} " \
+                  "Documented at: #{located}. " \
+                  'Consolidate the documentation into a single location.'
+              end
+
+              private
+
+              # Shortens an absolute "path:line" site to a path relative to the working
+              # directory for readability, leaving already-relative paths untouched.
+              # @param site [String] a "path:line" location
+              # @return [String] a display-friendly location
+              def relativize(site)
+                path, _, line = site.rpartition(':')
+                return site if path.empty?
+
+                relative = path.start_with?("#{Dir.pwd}/") ? path.sub("#{Dir.pwd}/", '') : path
+                "#{relative}:#{line}"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/duplicate_namespace_comment/parser.rb
+++ b/lib/yard/lint/validators/documentation/duplicate_namespace_comment/parser.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module DuplicateNamespaceComment
+          # Extracts duplicate namespace documentation offenses from raw collector output.
+          # Each line has the form "file:line: Namespace\tsite|site|...\tconflict" where
+          # conflict is either 'same' or 'differ'.
+          # @example Output format (skip-lint)
+          #   /a.rb:6: Foo::Bar\t/a.rb:6|/b.rb:6\tsame
+          class Parser < ::Yard::Lint::Parsers::Base
+            # Parses the "file:line: Namespace" head of an offense line. The namespace
+            # path uses '::' and never ': ', so the final ": " is an unambiguous separator.
+            LINE_REGEX = /\A(.+):(\d+): (.+)\z/
+
+            # @param output [String] raw collector output, one offense per line
+            # @return [Array<Hash>] offense hashes with location/line/namespace/sites/conflict
+            def call(output)
+              return [] if output.nil? || output.empty?
+
+              output.split("\n").filter_map do |line|
+                head, sites, conflict = line.split("\t")
+                next unless head
+
+                match = head.match(LINE_REGEX)
+                next unless match
+
+                {
+                  location: match[1],
+                  line: match[2].to_i,
+                  namespace: match[3],
+                  sites: (sites || '').split('|'),
+                  conflict: conflict
+                }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/duplicate_namespace_comment/result.rb
+++ b/lib/yard/lint/validators/documentation/duplicate_namespace_comment/result.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module DuplicateNamespaceComment
+          # Result object for duplicate namespace comment validation
+          # Transforms parsed offenses into offense objects
+          class Result < Results::Base
+            self.default_severity = 'warning'
+            self.offense_type = 'line'
+            self.offense_name = 'DuplicateNamespaceComment'
+
+            # Build human-readable message for a duplicate namespace comment offense
+            # @param offense [Hash] offense data with :namespace, :sites and :conflict keys
+            # @return [String] formatted message
+            def build_message(offense)
+              MessagesBuilder.call(offense)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/documentation/duplicate_namespace_comment/validator.rb
+++ b/lib/yard/lint/validators/documentation/duplicate_namespace_comment/validator.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Yard
+  module Lint
+    module Validators
+      module Documentation
+        module DuplicateNamespaceComment
+          # Flags namespaces (modules and classes) that carry a documentation comment in
+          # more than one file. YARD keeps only one docstring per object, so documenting
+          # the same reopened namespace in several files silently discards all but one of
+          # those comments. Because YARD does not record which reopening carried a comment,
+          # the source is re-read at each definition site to detect the documented ones.
+          class Validator < Base
+            # Enable in-process execution including private/protected objects
+            in_process visibility: :all
+
+            # Comment lines that are directives or magic comments rather than
+            # documentation. A definition preceded only by these is not "documented".
+            IGNORED_COMMENT = /
+              \A\#!                             # shebang
+              |\A\#\s*frozen_string_literal:    # frozen_string_literal magic comment
+              |\A\#\s*-\*-                       # editor modeline, e.g. -*- coding: utf-8 -*-
+              |\A\#\s*(en)?coding[:=]            # encoding magic comment
+              |\A\#\s*warn_indent:              # warn_indent magic comment
+              |\A\#\s*rubocop:                  # rubocop directive
+              |\A\#\s*:nodoc:                   # nodoc directive
+              |\A\#\s*yard-lint:                # yard-lint inline directive
+            /x
+
+            private_constant :IGNORED_COMMENT
+
+            # Execute query for a single object during in-process execution.
+            # Emits one line per namespace documented in two or more files.
+            # @param object [YARD::CodeObjects::Base] the code object to query
+            # @param collector [Executor::ResultCollector] collector for output
+            # @return [void]
+            def in_process_query(object, collector)
+              # Only namespaces (modules and classes) get reopened across files.
+              # NamespaceObject excludes methods, constants, and the like.
+              return unless object.is_a?(YARD::CodeObjects::NamespaceObject)
+              # A namespace defined in a single file can only be documented once.
+              return if object.files.size < 2
+
+              documented = object.files.select do |file, line|
+                line && documented_site?(file, line)
+              end
+
+              return if documented.size < 2
+
+              primary_file, primary_line = documented.first
+              sites = documented.map { |file, line| "#{file}:#{line}" }.join('|')
+              texts = documented.map { |file, line| doc_text(file, line) }
+              conflict = texts.uniq.size > 1 ? 'differ' : 'same'
+
+              collector.puts "#{primary_file}:#{primary_line}: #{object.title}\t#{sites}\t#{conflict}"
+            end
+
+            private
+
+            # Whether the definition at a location is preceded by a real doc comment,
+            # as opposed to no comment, a blank-separated (detached) comment, or only
+            # directive/magic comments.
+            # @param file [String] path to the source file
+            # @param line [Integer] 1-based line of the namespace definition
+            # @return [Boolean] true when the site carries documentation
+            def documented_site?(file, line)
+              !comment_lines(file, line).empty?
+            end
+
+            # Joins the documentation text at a location so identical and differing
+            # documentation across sites can be told apart.
+            # @param file [String] path to the source file
+            # @param line [Integer] 1-based line of the namespace definition
+            # @return [String] normalized comment text ('' when undocumented)
+            def doc_text(file, line)
+              comment_lines(file, line).join("\n")
+            end
+
+            # Collects the contiguous block of documentation comment lines directly
+            # above a definition, dropping directive/magic comments. A blank line
+            # between the comment and the definition detaches it (YARD behaviour), so
+            # scanning stops at the first blank or non-comment line.
+            # @param file [String] path to the source file
+            # @param line [Integer] 1-based line of the namespace definition
+            # @return [Array<String>] normalized documentation lines
+            def comment_lines(file, line)
+              lines = source_lines(file)
+              return [] if lines.empty?
+
+              collected = []
+              index = line - 2 # zero-based line directly above the definition
+
+              while index >= 0
+                text = lines[index].strip
+                break if text.empty? || !text.start_with?('#')
+
+                collected << text unless text.match?(IGNORED_COMMENT)
+                index -= 1
+              end
+
+              collected
+            end
+
+            # Reads source lines for a file, tolerating unreadable paths so a single
+            # bad location drops only its own site instead of hiding the whole object.
+            # @param file [String] path to the source file
+            # @return [Array<String>] file lines, or an empty array when unreadable
+            def source_lines(file)
+              cached_lines(file)
+            rescue SystemCallError, IOError
+              []
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/lint/validators/tags/example_syntax.rb
+++ b/lib/yard/lint/validators/tags/example_syntax.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Tags validators - validate YARD tag quality and consistency
       module Tags
         # ExampleSyntax validator
         #

--- a/lib/yard/lint/validators/tags/redundant_param_description.rb
+++ b/lib/yard/lint/validators/tags/redundant_param_description.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Tags validators - validate YARD tag quality and consistency
       module Tags
         # RedundantParamDescription validator
         #

--- a/lib/yard/lint/validators/warnings/duplicated_parameter_name.rb
+++ b/lib/yard/lint/validators/warnings/duplicated_parameter_name.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
         # DuplicatedParameterName validator
         #
@@ -29,7 +28,6 @@ module Yard
         #
         #     Warnings/DuplicatedParameterName:
         #       Enabled: false
-        #
         module DuplicatedParameterName
         end
       end

--- a/lib/yard/lint/validators/warnings/invalid_directive_format.rb
+++ b/lib/yard/lint/validators/warnings/invalid_directive_format.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
         # InvalidDirectiveFormat validator
         #
@@ -29,7 +28,6 @@ module Yard
         #
         #     Warnings/InvalidDirectiveFormat:
         #       Enabled: false
-        #
         module InvalidDirectiveFormat
         end
       end

--- a/lib/yard/lint/validators/warnings/invalid_directive_format/config.rb
+++ b/lib/yard/lint/validators/warnings/invalid_directive_format/config.rb
@@ -3,9 +3,7 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
-        # Validator for detecting invalid directive formats
         module InvalidDirectiveFormat
           # Configuration for InvalidDirectiveFormat validator
           class Config < ::Yard::Lint::Validators::Config

--- a/lib/yard/lint/validators/warnings/invalid_tag_format.rb
+++ b/lib/yard/lint/validators/warnings/invalid_tag_format.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
         # InvalidTagFormat validator
         #
@@ -29,7 +28,6 @@ module Yard
         #
         #     Warnings/InvalidTagFormat:
         #       Enabled: false
-        #
         module InvalidTagFormat
         end
       end

--- a/lib/yard/lint/validators/warnings/invalid_tag_format/config.rb
+++ b/lib/yard/lint/validators/warnings/invalid_tag_format/config.rb
@@ -3,9 +3,7 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
-        # Validator for detecting invalid tag formats
         module InvalidTagFormat
           # Configuration for InvalidTagFormat validator
           class Config < ::Yard::Lint::Validators::Config

--- a/lib/yard/lint/validators/warnings/syntax_error.rb
+++ b/lib/yard/lint/validators/warnings/syntax_error.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
         # SyntaxError validator
         #
@@ -25,7 +24,6 @@ module Yard
         #
         #     Warnings/SyntaxError:
         #       Enabled: false
-        #
         module SyntaxError
         end
       end

--- a/lib/yard/lint/validators/warnings/syntax_error/config.rb
+++ b/lib/yard/lint/validators/warnings/syntax_error/config.rb
@@ -3,9 +3,7 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
-        # Validator for detecting files YARD could not parse
         module SyntaxError
           # Configuration for SyntaxError validator
           class Config < ::Yard::Lint::Validators::Config

--- a/lib/yard/lint/validators/warnings/unknown_directive.rb
+++ b/lib/yard/lint/validators/warnings/unknown_directive.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
         # UnknownDirective validator
         #
@@ -30,7 +29,6 @@ module Yard
         #
         #     Warnings/UnknownDirective:
         #       Enabled: false
-        #
         module UnknownDirective
         end
       end

--- a/lib/yard/lint/validators/warnings/unknown_directive/config.rb
+++ b/lib/yard/lint/validators/warnings/unknown_directive/config.rb
@@ -3,9 +3,7 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
-        # Validator for detecting unknown directives
         module UnknownDirective
           # Configuration for UnknownDirective validator
           class Config < ::Yard::Lint::Validators::Config

--- a/lib/yard/lint/validators/warnings/unknown_parameter_name.rb
+++ b/lib/yard/lint/validators/warnings/unknown_parameter_name.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
         # UnknownParameterName validator
         #
@@ -27,7 +26,6 @@ module Yard
         #
         #     Warnings/UnknownParameterName:
         #       Enabled: false
-        #
         module UnknownParameterName
         end
       end

--- a/lib/yard/lint/validators/warnings/unknown_parameter_name/config.rb
+++ b/lib/yard/lint/validators/warnings/unknown_parameter_name/config.rb
@@ -3,9 +3,7 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
-        # Validator for detecting unknown parameter names in @param tags
         module UnknownParameterName
           # Configuration for UnknownParameterName validator
           class Config < ::Yard::Lint::Validators::Config

--- a/lib/yard/lint/validators/warnings/unknown_tag.rb
+++ b/lib/yard/lint/validators/warnings/unknown_tag.rb
@@ -3,7 +3,6 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
         # UnknownTag validator
         #
@@ -40,7 +39,6 @@ module Yard
         #
         #     Warnings/UnknownTag:
         #       Enabled: false
-        #
         module UnknownTag
         end
       end

--- a/lib/yard/lint/validators/warnings/unknown_tag/config.rb
+++ b/lib/yard/lint/validators/warnings/unknown_tag/config.rb
@@ -3,9 +3,7 @@
 module Yard
   module Lint
     module Validators
-      # Validators for checking YARD warnings
       module Warnings
-        # Validator for detecting unknown tags in documentation
         module UnknownTag
           # Configuration for UnknownTag validator
           class Config < ::Yard::Lint::Validators::Config

--- a/lib/yard/lint/version.rb
+++ b/lib/yard/lint/version.rb
@@ -3,6 +3,6 @@
 module Yard
   module Lint
     # @return [String] version of the YARD Lint gem
-    VERSION = '1.9.0'
+    VERSION = '1.10.0'
   end
 end

--- a/test/integrations/duplicate_namespace_comment_test.rb
+++ b/test/integrations/duplicate_namespace_comment_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+describe 'Documentation/DuplicateNamespaceComment' do
+  attr_reader :dirs
+
+  before { @dirs = [] }
+  after { @dirs.each { |dir| FileUtils.rm_rf(dir) } }
+
+  # Lint the given file path(s) and return only this validator's offenses.
+  # @param paths [String, Array<String>] file path(s) to lint
+  # @return [Array<Hash>] offenses produced by Documentation/DuplicateNamespaceComment
+  def offenses_for(paths)
+    Yard::Lint
+      .run(path: Array(paths), config: test_config, progress: false)
+      .offenses
+      .select { |offense| offense[:validator] == 'Documentation/DuplicateNamespaceComment' }
+  end
+
+  # Write {filename => source} into a fresh tmp dir, in order, and return the paths.
+  # @param files [Hash{String => String}] filename to Ruby source
+  # @return [Array<String>] absolute paths, in insertion order
+  def write_files(files)
+    dir = Dir.mktmpdir
+    @dirs << dir
+    files.map do |name, content|
+      path = File.join(dir, name)
+      File.write(path, content)
+      path
+    end
+  end
+
+  # @param name [String] fixture file name
+  # @return [String] absolute path to a committed fixture
+  def fixture(name)
+    File.expand_path("fixtures/#{name}", __dir__)
+  end
+
+  describe 'committed fixtures' do
+    let(:documented_pair) do
+      [fixture('duplicate_namespace_a.rb'), fixture('duplicate_namespace_b.rb')]
+    end
+
+    it 'flags a namespace documented in two files' do
+      offenses = offenses_for(documented_pair)
+
+      assert_equal(1, offenses.size)
+      assert_equal('DuplicateNamespaceComment', offenses.first[:name])
+      assert_includes(offenses.first[:message], '`DuplicateNs`')
+    end
+
+    it 'reports the same single offense regardless of file order' do
+      assert_equal(1, offenses_for(documented_pair).size)
+      assert_equal(1, offenses_for(documented_pair.reverse).size)
+    end
+
+    it 'lists both documented locations in the message' do
+      message = offenses_for(documented_pair).first[:message]
+
+      assert_includes(message, 'duplicate_namespace_a.rb')
+      assert_includes(message, 'duplicate_namespace_b.rb')
+    end
+
+    it 'does not flag leaf classes defined in a single file' do
+      messages = offenses_for(documented_pair).map { |offense| offense[:message] }
+
+      refute(messages.any? { |message| message.include?('`DuplicateNs::Leaf`') })
+      refute(messages.any? { |message| message.include?('`DuplicateNs::Other`') })
+    end
+
+    it 'does not flag a namespace documented in only one of the files' do
+      pair = [fixture('duplicate_namespace_a.rb'), fixture('duplicate_namespace_c.rb')]
+
+      assert_empty(offenses_for(pair))
+    end
+  end
+
+  describe 'detection details' do
+    it 'marks differing docstrings as a content-losing conflict' do
+      paths = write_files(
+        'a.rb' => "# frozen_string_literal: true\n\n# First description.\nmodule Shared\nend\n",
+        'b.rb' => "# frozen_string_literal: true\n\n# Second, different description.\nmodule Shared\nend\n"
+      )
+
+      message = offenses_for(paths).first[:message]
+
+      assert_includes(message, 'docstrings differ')
+    end
+
+    it 'flags identical duplicated docstrings without a conflict note' do
+      doc = "# frozen_string_literal: true\n\n# Same description.\nmodule Shared\nend\n"
+      paths = write_files('a.rb' => doc, 'b.rb' => doc)
+
+      offenses = offenses_for(paths)
+
+      assert_equal(1, offenses.size)
+      refute_includes(offenses.first[:message], 'docstrings differ')
+    end
+
+    it 'produces a warning severity offense' do
+      doc = "# Description here.\nmodule Shared\nend\n"
+      paths = write_files('a.rb' => doc, 'b.rb' => doc)
+
+      assert_equal('warning', offenses_for(paths).first[:severity])
+    end
+
+    it 'flags classes reopened and documented across files' do
+      paths = write_files(
+        'a.rb' => "# A shared class.\nclass Shared\nend\n",
+        'b.rb' => "# A shared class, reopened.\nclass Shared\nend\n"
+      )
+
+      offenses = offenses_for(paths)
+
+      assert_equal(1, offenses.size)
+      assert_includes(offenses.first[:message], '`Shared`')
+    end
+
+    it 'counts every documented file' do
+      doc = "# Shared description.\nmodule Shared\nend\n"
+      paths = write_files('a.rb' => doc, 'b.rb' => doc, 'c.rb' => doc)
+
+      offenses = offenses_for(paths)
+
+      assert_equal(1, offenses.size)
+      assert_includes(offenses.first[:message], 'documented in 3 files')
+    end
+
+    it 'does not count magic comments as documentation' do
+      src = "# frozen_string_literal: true\nmodule Shared\nend\n"
+      paths = write_files('a.rb' => src, 'b.rb' => src)
+
+      assert_empty(offenses_for(paths))
+    end
+
+    it 'does not count a blank-line-detached comment as documentation' do
+      src = "# Detached comment.\n\nmodule Shared\nend\n"
+      paths = write_files('a.rb' => src, 'b.rb' => src)
+
+      assert_empty(offenses_for(paths))
+    end
+
+    it 'does not count rubocop directives as documentation' do
+      src = "# rubocop:disable Style/Documentation\nmodule Shared\nend\n"
+      paths = write_files('a.rb' => src, 'b.rb' => src)
+
+      assert_empty(offenses_for(paths))
+    end
+
+    it 'does not flag a namespace documented in exactly one file' do
+      paths = write_files(
+        'a.rb' => "# Documented once.\nmodule Shared\nend\n",
+        'b.rb' => "module Shared\nend\n"
+      )
+
+      assert_empty(offenses_for(paths))
+    end
+  end
+end

--- a/test/integrations/fixtures/duplicate_namespace_a.rb
+++ b/test/integrations/fixtures/duplicate_namespace_a.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Groups the user-facing operations for the demo namespace.
+module DuplicateNs
+  # A leaf class documented in exactly one file, so it is never flagged.
+  class Leaf
+    # @return [Symbol] the leaf marker
+    def name
+      :leaf
+    end
+  end
+end

--- a/test/integrations/fixtures/duplicate_namespace_b.rb
+++ b/test/integrations/fixtures/duplicate_namespace_b.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Adds shared helpers to the demo namespace in a second file.
+module DuplicateNs
+  # Another leaf, also defined in exactly one file.
+  class Other
+    # @return [Symbol] the other marker
+    def name
+      :other
+    end
+  end
+end

--- a/test/integrations/fixtures/duplicate_namespace_c.rb
+++ b/test/integrations/fixtures/duplicate_namespace_c.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DuplicateNs
+  # A leaf added without re-documenting the namespace itself.
+  class Third
+    # @return [Symbol] the third marker
+    def name
+      :third
+    end
+  end
+end

--- a/test/yard/lint/validators/documentation/duplicate_namespace_comment_test.rb
+++ b/test/yard/lint/validators/documentation/duplicate_namespace_comment_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+describe 'Yard::Lint::Validators::Documentation::DuplicateNamespaceComment' do
+  it 'is a module' do
+    assert_kind_of(Module, Yard::Lint::Validators::Documentation::DuplicateNamespaceComment)
+  end
+
+  it 'has required sub modules and classes' do
+    mod = Yard::Lint::Validators::Documentation::DuplicateNamespaceComment
+    assert_equal(true, mod.const_defined?(:Config))
+    assert_equal(true, mod.const_defined?(:Validator))
+    assert_equal(true, mod.const_defined?(:Parser))
+    assert_equal(true, mod.const_defined?(:Result))
+    assert_equal(true, mod.const_defined?(:MessagesBuilder))
+  end
+
+  it 'is discovered by the config loader' do
+    assert_includes(
+      Yard::Lint::ConfigLoader::ALL_VALIDATORS,
+      'Documentation/DuplicateNamespaceComment'
+    )
+  end
+end
+
+describe 'Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Config' do
+  it 'id returns the validator identifier' do
+    assert_equal(
+      :duplicate_namespace_comment,
+      Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Config.id
+    )
+  end
+
+  it 'defaults returns default configuration' do
+    assert_equal(
+      { 'Enabled' => true, 'Severity' => 'warning' },
+      Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Config.defaults
+    )
+  end
+
+  it 'defaults returns frozen hash' do
+    assert_predicate(
+      Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Config.defaults,
+      :frozen?
+    )
+  end
+
+  it 'inheritance inherits from base config class' do
+    assert_equal(
+      Yard::Lint::Validators::Config,
+      Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Config.superclass
+    )
+  end
+end
+
+describe 'Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Validator' do
+  it 'supports in-process execution' do
+    assert_equal(
+      true,
+      Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Validator.in_process?
+    )
+  end
+
+  it 'inherits from the base validator' do
+    validator = Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Validator.new(
+      Yard::Lint::Config.new, ['lib/example.rb']
+    )
+    assert_kind_of(Yard::Lint::Validators::Base, validator)
+  end
+
+  it 'treats an unreadable definition site as undocumented' do
+    validator = Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Validator.new(
+      Yard::Lint::Config.new, []
+    )
+
+    refute(validator.send(:documented_site?, '/nonexistent/does_not_exist.rb', 5))
+  end
+end
+
+describe 'Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Parser' do
+  def parser
+    Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::Parser.new
+  end
+
+  it 'returns an empty array for empty input' do
+    assert_empty(parser.call(''))
+    assert_empty(parser.call(nil))
+  end
+
+  it 'parses a single offense line' do
+    line = "/a.rb:6: Foo::Bar\t/a.rb:6|/b.rb:9\tdiffer"
+
+    assert_equal(
+      [
+        {
+          location: '/a.rb',
+          line: 6,
+          namespace: 'Foo::Bar',
+          sites: ['/a.rb:6', '/b.rb:9'],
+          conflict: 'differ'
+        }
+      ],
+      parser.call(line)
+    )
+  end
+
+  it 'parses a fully qualified namespace that contains ::' do
+    line = "/x.rb:3: Yard::Lint::Validators::Warnings\t/x.rb:3|/y.rb:3\tsame"
+    parsed = parser.call(line).first
+
+    assert_equal('Yard::Lint::Validators::Warnings', parsed[:namespace])
+    assert_equal('same', parsed[:conflict])
+  end
+
+  it 'parses multiple lines and skips malformed ones' do
+    output = [
+      "/a.rb:1: A\t/a.rb:1|/b.rb:1\tsame",
+      'garbage-without-location',
+      "/c.rb:2: C\t/c.rb:2|/d.rb:2\tdiffer"
+    ].join("\n")
+
+    parsed = parser.call(output)
+
+    assert_equal(2, parsed.size)
+    assert_equal(%w[A C], parsed.map { |offense| offense[:namespace] })
+  end
+end
+
+describe 'Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::MessagesBuilder' do
+  def build(offense)
+    Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::MessagesBuilder.call(offense)
+  end
+
+  it 'names the namespace, count and locations' do
+    message = build(namespace: 'Foo::Bar', sites: ['a.rb:1', 'b.rb:2'], conflict: 'same')
+
+    assert_includes(message, '`Foo::Bar`')
+    assert_includes(message, 'documented in 2 files')
+    assert_includes(message, 'a.rb:1')
+    assert_includes(message, 'b.rb:2')
+  end
+
+  it 'notes lost content only when the docstrings differ' do
+    differ = build(namespace: 'A', sites: ['a.rb:1', 'b.rb:2'], conflict: 'differ')
+    same = build(namespace: 'A', sites: ['a.rb:1', 'b.rb:2'], conflict: 'same')
+
+    assert_includes(differ, 'docstrings differ')
+    refute_includes(same, 'docstrings differ')
+  end
+
+  it 'truncates long location lists' do
+    sites = (1..8).map { |i| "file_#{i}.rb:#{i}" }
+    message = build(namespace: 'A', sites: sites, conflict: 'same')
+
+    assert_includes(message, 'documented in 8 files')
+    assert_includes(message, '(+3 more)')
+  end
+
+  it 'leaves a location with no line number untouched' do
+    klass = Yard::Lint::Validators::Documentation::DuplicateNamespaceComment::MessagesBuilder
+
+    assert_equal('plainpath', klass.send(:relativize, 'plainpath'))
+  end
+end


### PR DESCRIPTION
## What

Adds a new validator, **`Documentation/DuplicateNamespaceComment`**, that detects namespaces (modules and classes) documented in more than one file.

When a namespace is reopened across several files and a YARD doc comment is written above more than one of those reopenings, YARD merges the reopenings into a single object and keeps only **one** docstring — the last documented reopening wins, silently, with no warning. Competing descriptions are lost. This is an easy accident for shared namespaces (e.g. `Users`, `Users::Operations`) spread across many files; it never affects a leaf object such as `Users::Operations::Create` that lives in a single file.

## How it works

YARD does not record which reopening carried a comment (only the final winning docstring survives), so the validator re-reads each definition site listed in `object.files` and detects the leading `#` doc block, ignoring:

- blank-line-detached comments (YARD detaches these),
- directive/magic comments (`frozen_string_literal`, `encoding`, shebang, `rubocop:`, `:nodoc:`, `yard-lint:`).

It reports **one offense per namespace** documented in 2+ files, listing every documented location and noting when the docstrings **differ** (i.e. content is actually being lost).

- **Scope:** modules + classes (`YARD::CodeObjects::NamespaceObject`); methods/constants excluded.
- **Default:** enabled, severity `warning`. Configurable via the standard `Enabled` / `Severity` keys.
- Auto-discovered by `ConfigLoader`; registered in `.yard-lint.yml` and both config templates.

## Dogfooding found (and this PR fixes) 11 real cases

Running it on `lib/` surfaced genuine doc-overwrite bugs — e.g. `Warnings::DuplicatedParameterName` was documented with a one-liner in `config.rb` **and** a rich description in its orchestrator file, differing, so one was being silently dropped. Each affected namespace is consolidated to a single canonical doc location (this also resolved 7 trailing-`#` `EmptyCommentLine` issues the change surfaced). `bin/yard-lint lib/` is clean.

## Tests

- Unit tests (config / discovery / parser / messages builder, incl. defensive branches).
- Multi-file integration tests (both file orders, identical vs differing docstrings, class namespaces, magic/detached/rubocop comment handling, negatives).
- Full suite: **2394 runs, 0 failures**, including the validator-coverage / template-parity / config-generator / config-updater tests that enumerate every validator.

## Also

- CHANGELOG entry and version bump to **1.10.0**.
- README validator count updated to 37.

> Note: per-validator prose lives on the external wiki (`.../wiki/Validators`) — a page for this validator still needs to be added there (out of repo scope).