### PR TITLE
Enable TextSubstitution as error in own config

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -93,8 +93,8 @@ Documentation/UnderfilledLines:
 
 Documentation/TextSubstitution:
   Description: 'Detects forbidden characters or strings in documentation and suggests replacements.'
-  Enabled: false  # Opt-in validator
-  Severity: warning
+  Enabled: true
+  Severity: error
   Substitutions:
     "—": "-"    # em-dash (U+2014)
     "–": "-"    # en-dash (U+2013)

--- a/lib/yard/lint.rb
+++ b/lib/yard/lint.rb
@@ -25,7 +25,7 @@ module Yard
       #   - :mode [Symbol] one of :ref, :staged, :changed
       #   - :base_ref [String, nil] base ref for :ref mode (auto-detects main/master if nil)
       # @param source [String, nil] in-memory source content; when given, the file is not
-      #   read from disk — `path` must be a single .rb file path (used for config/exclusion
+      #   read from disk - `path` must be a single .rb file path (used for config/exclusion
       #   resolution and offense location reporting only)
       # @return [Yard::Lint::Result] result object with offenses
       def run(path:, config: nil, config_file: nil, progress: nil, diff: nil, source: nil)

--- a/lib/yard/lint/validators/base.rb
+++ b/lib/yard/lint/validators/base.rb
@@ -186,7 +186,7 @@ module Yard
             superclass_path = superclass.respond_to?(:path) ? superclass.path.to_s : superclass.to_s
             next false if superclass_path.empty?
             # Every Ruby class without an explicit parent implicitly inherits from Object,
-            # so matching it would exempt all classes — never the intent.
+            # so matching it would exempt all classes - never the intent.
             # BasicObject is the root of the hierarchy and is guarded for the same reason.
             next false if superclass_path == 'Object' || superclass_path == 'BasicObject'
 
@@ -199,10 +199,10 @@ module Yard
         # object without reporting an offense.
         #
         # Three pattern forms are supported (matching ExcludedMethods convention):
-        #   - Exact name:    'call'          — matches any arity
-        #   - Arity:         'initialize/1'  — matches only the given parameter count
+        #   - Exact name:    'call'          - matches any arity
+        #   - Arity:         'initialize/1'  - matches only the given parameter count
         #                                      (required + optional, excluding * and &)
-        #   - Regex:         '/^perform/'    — matches against the bare method name
+        #   - Regex:         '/^perform/'    - matches against the bare method name
         #
         # Invalid regex patterns are silently ignored. The empty regex '//' is always
         # rejected (it would match every method, making the option useless).

--- a/lib/yard/lint/validators/documentation/line_length.rb
+++ b/lib/yard/lint/validators/documentation/line_length.rb
@@ -11,7 +11,7 @@ module Yard
         # above a documentable Ruby construct). YARD's parsed docstring is used to
         # determine which lines belong to a docstring, avoiding fragile backwards-scanning.
         #
-        # Disabled by default — enable it and set MaxLength to taste.
+        # Disabled by default - enable it and set MaxLength to taste.
         #
         # @example Bad - line exceeds MaxLength (120)
         #   # This documentation line is too long and exceeds the configured maximum length.

--- a/lib/yard/lint/validators/documentation/line_length/validator.rb
+++ b/lib/yard/lint/validators/documentation/line_length/validator.rb
@@ -9,7 +9,7 @@ module Yard
           #
           # Uses YARD's `docstring.line_range` to locate the exact source lines belonging to
           # each docstring block. This handles block comments, wrapped tag descriptions, and
-          # macro expansion correctly — no arithmetic reconstruction needed.
+          # macro expansion correctly - no arithmetic reconstruction needed.
           class Validator < Validators::Base
             in_process visibility: :all
 

--- a/lib/yard/lint/validators/documentation/text_substitution.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution.rb
@@ -8,17 +8,17 @@ module Yard
         #
         # Detects forbidden characters or strings in YARD documentation comments
         # and suggests replacements. The primary use case is detecting AI-generated
-        # em-dashes (—, U+2014) and en-dashes (–, U+2013) where a plain hyphen (-)
+        # em-dashes (-, U+2014) and en-dashes (-, U+2013) where a plain hyphen (-)
         # is preferred, but any string-to-string substitution rule can be configured.
         #
-        # All substitution rules are checked on every line — multiple violations can
+        # All substitution rules are checked on every line - multiple violations can
         # be reported for the same line when more than one forbidden string appears.
         # Fenced code blocks (``` ... ```) are skipped.
         #
-        # Disabled by default — enable it and configure Substitutions to taste.
+        # Disabled by default - enable it and configure Substitutions to taste.
         #
         # @example Bad - em-dash used in documentation
-        #   # Connects the start — and end of the range.
+        #   # Connects the start - and end of the range.
         #   def connect(start, finish)
         #   end
         #
@@ -39,8 +39,8 @@ module Yard
         #     Documentation/TextSubstitution:
         #       Enabled: true
         #       Substitutions:
-        #         "—": "-"    # em-dash (U+2014)
-        #         "–": "-"    # en-dash (U+2013)
+        #         "-": "-"    # em-dash (U+2014)
+        #         "-": "-"    # en-dash (U+2013)
         #         "…": "..."  # ellipsis (U+2026)
         #
         # To disable:

--- a/lib/yard/lint/validators/documentation/text_substitution/parser.rb
+++ b/lib/yard/lint/validators/documentation/text_substitution/parser.rb
@@ -22,7 +22,7 @@ module Yard
             def call(yard_output, **_kwargs)
               return [] if yard_output.nil? || yard_output.strip.empty?
 
-              # Do not strip lines — forbidden/replacement may have significant whitespace
+              # Do not strip lines - forbidden/replacement may have significant whitespace
               lines = yard_output.split("\n")
               violations = []
 


### PR DESCRIPTION
Dogfoods the standard: flips `Documentation/TextSubstitution` to `Enabled: true` / `Severity: error` (em-dash `—` and en-dash `–` -> `-`) and replaces the existing em/en-dashes in the gem's own docs. `bin/yard-lint lib/` reports `No offenses found`.