### PR TITLE
Backfill missing gemspec metadata

### DIFF
--- a/yard-lint.gemspec
+++ b/yard-lint.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/mensfeld/yard-lint'
   spec.metadata['changelog_uri'] = 'https://github.com/mensfeld/yard-lint/blob/master/CHANGELOG.md'
+  spec.metadata['bug_tracker_uri'] = 'https://github.com/mensfeld/yard-lint/issues'
+  spec.metadata['documentation_uri'] = 'https://github.com/mensfeld/yard-lint'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Adds the `metadata` keys this gem was missing relative to the rest of the fleet (per the gemspec audit): **bug_tracker_uri documentation_uri **

- URIs point at the standard GitHub locations (`/issues` for bug tracker, repo URL for docs/homepage), matching the repo's existing quote/interpolation style.
- Improves the rubygems.org sidebar links.

Gemspec loads cleanly (`Gem::Specification.load`); no other changes.